### PR TITLE
Update release action

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,9 +1,9 @@
 [bumpversion]
-current_version = 1.0.0
+current_version = 1.0.1b1
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((?P<release>b)+(?P<build>\d+))?
-serialize =
+serialize = 
 	{major}.{minor}.{patch}{release}{build}
 	{major}.{minor}.{patch}
 
@@ -12,7 +12,7 @@ serialize =
 [bumpversion:part:release]
 first_value = b
 optional_value = _
-values =
+values = 
 	b
 	_
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,20 @@
+[bumpversion]
+current_version = 1.0.0
+commit = False
+tag = False
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((?P<release>b)+(?P<build>\d+))?
+serialize =
+	{major}.{minor}.{patch}{release}{build}
+	{major}.{minor}.{patch}
+
+[bumpversion:file:src/forge/__init__.py]
+
+[bumpversion:part:release]
+first_value = b
+optional_value = _
+values =
+	b
+	_
+
+[bumpversion:part:build]
+first_value = 1

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,6 +1,6 @@
 [bumpversion]
 current_version = 1.0.0
-commit = False
+commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((?P<release>b)+(?P<build>\d+))?
 serialize =

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,9 +1,9 @@
 [bumpversion]
-current_version = 1.0.1b1
+current_version = 1.0.0
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((?P<release>b)+(?P<build>\d+))?
-serialize = 
+serialize =
 	{major}.{minor}.{patch}{release}{build}
 	{major}.{minor}.{patch}
 
@@ -12,7 +12,7 @@ serialize =
 [bumpversion:part:release]
 first_value = b
 optional_value = _
-values = 
+values =
 	b
 	_
 

--- a/.github/scripts/generate_rn.py
+++ b/.github/scripts/generate_rn.py
@@ -1,0 +1,32 @@
+"""Extract a section of the changelog specific to a given version."""
+import configparser
+
+config = configparser.ConfigParser()
+with open(".bumpversion.cfg", "r", encoding="utf-8") as fobj:
+    config.read_file(fobj)
+    version = config['bumpversion']['current_version']
+
+rn = f"""
+```
+pip install cars-forge=={version}
+```
+
+---"""
+with open("CHANGELOG.md", "r", encoding="utf-8") as changelog:
+    is_read = False
+    for line in changelog:
+        # Starting current version section of changelog
+        if version in line:
+            is_read = True
+        # Done with current version
+        elif line.startswith("## [") and version not in line:
+            is_read = False
+        elif is_read and (line != ""):
+            rn += line
+
+# Print version to stdout. This should be captured by a workflow step:
+# python generate_rn.py >> $GITHUB_ENV
+print(f"VERSION={version}")
+
+with open("release_notes.md", "w", encoding="utf-8") as release_notes:
+    release_notes.write(rn)

--- a/.github/scripts/generate_rn.py
+++ b/.github/scripts/generate_rn.py
@@ -24,9 +24,5 @@ with open("CHANGELOG.md", "r", encoding="utf-8") as changelog:
         elif is_read and (line != ""):
             rn += line
 
-# Print version to stdout. This should be captured by a workflow step:
-# python generate_rn.py >> $GITHUB_ENV
-print(f"VERSION={version}")
-
 with open("release_notes.md", "w", encoding="utf-8") as release_notes:
     release_notes.write(rn)

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -41,12 +41,20 @@ jobs:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}
 
+    - name: Fetch current version
+      run: |
+        VER=$(awk '/^current_version/{print $NF}' .bumpversion.cfg)
+        echo "VERSION=$VER" >> $GITHUB_ENV
+
     - name: Build Release Notes from Changelog
-        # This script prints the version number as an env variable called `VERSION`
-        run: python .github/scripts/generate_rn.py >> $GITHUB_ENV
+      # Don't release beta versions on GitHub
+      if: contains(env.VERSION, 'b') != true
+      run: python .github/scripts/generate_rn.py
 
     - name: Release
       uses: softprops/action-gh-release@v1
+      # Don't release beta versions on GitHub
+      if: contains(env.VERSION, 'b') != true
       with:
         name: Version ${{ env.VERSION }}
         tag_name: v${{ env.VERSION }}

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,12 +1,4 @@
-# This workflow will upload a Python Package using Twine when a release is created
-# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
-
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
-name: Upload Python Package
+name: Publish Package
 
 on:
   # Run on pushes to `main` branch that modify the bump2version file where
@@ -29,18 +21,33 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+
     - name: Set up Python
       uses: actions/setup-python@v3
       with:
         python-version: '3.7'
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install build
+
     - name: Build package
       run: python -m build -s -w
+
     - name: Publish package to PyPi
       uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}
+
+    - name: Build Release Notes from Changelog
+        # This script prints the version number as an env variable called `VERSION`
+        run: python .github/scripts/generate_rn.py >> $GITHUB_ENV
+
+    - name: Release
+      uses: softprops/action-gh-release@v1
+      with:
+        name: Version ${{ env.VERSION }}
+        tag_name: v${{ env.VERSION }}
+        body_path: release_notes.md

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -10,7 +10,7 @@ on:
       - '.bumpversion.cfg'
 
   # Allows running this workflow manually from the Actions tab
-  workflow_dispatch
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -9,9 +9,16 @@
 name: Upload Python Package
 
 on:
+  # Run on pushes to `main` branch that modify the bump2version file where
+  # version is stored
   push:
     branches:
       - main
+    paths:
+      - '.bumpversion.cfg'
+
+  # Allows running this workflow manually from the Actions tab
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -33,7 +40,6 @@ jobs:
     - name: Build package
       run: python -m build -s -w
     - name: Publish package to PyPi
-      if: startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
       with:
         user: __token__

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -10,7 +10,7 @@ on:
       - '.bumpversion.cfg'
 
   # Allows running this workflow manually from the Actions tab
-  workflow_dispatch:
+  workflow_dispatch
 
 permissions:
   contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+- **GitHub** - Update action to build and publish package only when version is bumped.
+
+
+## [1.0.0] - 2022-09-27
+
 ### Added
 - **Initial commit** - Forge source code, unittests, docs, pyproject.toml, README.md, and LICENSE files.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+- **Version** - Use `bump2version` to manage project version.
+- **Dependencies** - Add `bump2version` as a dev dependency.
+
 ### Changed
+- **GitHub** - Add step to create GitHub release after uploading to PYPI.
 - **GitHub** - Update action to build and publish package only when version is bumped.
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,9 @@ dependencies = [
 test = [
     "pytest~=7.1.0",
 ]
+dev = [
+    "bump2version~=1.0",
+]
 
 [project.urls]
 homepage = "https://github.com/carsdotcom/cars-forge/"

--- a/src/forge/__init__.py
+++ b/src/forge/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.0.1b1"
+__version__ = "1.0.0"
 
 # Default values for forge's essential arguments
 DEFAULT_ARG_VALS = {

--- a/src/forge/__init__.py
+++ b/src/forge/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.0.0"
+__version__ = "1.0.1b1"
 
 # Default values for forge's essential arguments
 DEFAULT_ARG_VALS = {


### PR DESCRIPTION
With this PR, the workflow to release a new version becomes:

1. Write your code
2. Bump the appropriate version part (`major`/`minor`/`patch`):
    ```
    bump2version major/minor/patch
    ```
    This makes a new commit with X.Y.Zb1. **We always start a new version as a beta release**
4. Test the changes. If code is not yet ready for release but more changes are needed, then make a new beta version:
    ```
    bump2version build
    ```
    This makes a new commit with X.Y.Zb2
5. Once code is stable, then make this version as final:
    ```
    bump2version release
    ```
    This makes a new commit with X.Y.Z

Anytime a PR is merged with a modified `.bumpversion.cfg` we will try to make a new release to PYPI, beta or otherwise. Only final versions are released to GitHub.

We can obviously change this if it becomes too much work.