### PR TITLE
Added forge-name as an automatic tag

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,9 +1,9 @@
 [bumpversion]
-current_version = 1.0.0
+current_version = 1.0.1b1
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((?P<release>b)+(?P<build>\d+))?
-serialize =
+serialize = 
 	{major}.{minor}.{patch}{release}{build}
 	{major}.{minor}.{patch}
 
@@ -12,7 +12,7 @@ serialize =
 [bumpversion:part:release]
 first_value = b
 optional_value = _
-values =
+values = 
 	b
 	_
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.1b1
+current_version = 1.0.1
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((?P<release>b)+(?P<build>\d+))?

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# Byte-compiled and optimized python files
+__pycache__/
+*.py[cod]
+
+# pytest cache
+.pytest_cache/
+
+# coverage report
+.coverage
+
+# macOS stuff
+.DS_Store
+
+# Build files
+*.egg-info/
+build/
+dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - **Metadata** - Fix License field and capitalize project urls.
 - **GitHub** - Add step to create GitHub release after uploading to PYPI.
 - **GitHub** - Update action to build and publish package only when version is bumped.
-
+- **Forge** - Added automatic tag `forge-name` to allow `Name` tag to be changed.
 
 ## [1.0.0] - 2022-09-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### Added
+- **gitignore** - Use a `.gitignore` file to prevent accidentally committing unneeded files.
 - **Version** - Use `bump2version` to manage project version.
 - **Dependencies** - Add `bump2version` as a dev dependency.
 
 ### Changed
+- **Metadata** - Fix License field and capitalize project urls.
 - **GitHub** - Add step to create GitHub release after uploading to PYPI.
 - **GitHub** - Update action to build and publish package only when version is bumped.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ name = "cars-forge"
 description = "Create an on-demand/spot fleet of single or cluster EC2 instances."
 readme = "README.md"
 requires-python = ">=3.7"
-license = {file = "LICENSE"}
+license = "Apache-2.0"
 authors = [
     {name = "Nikhil Patel", email = "npatel@cars.com"}
 ]
@@ -50,9 +50,9 @@ dev = [
 ]
 
 [project.urls]
-homepage = "https://github.com/carsdotcom/cars-forge/"
-documentation = "https://carsdotcom.github.io/cars-forge/"
-changelog = "https://github.com/carsdotcom/cars-forge/blob/main/CHANGELOG.md"
+Homepage = "https://github.com/carsdotcom/cars-forge/"
+Documentation = "https://carsdotcom.github.io/cars-forge/"
+Changelog = "https://github.com/carsdotcom/cars-forge/blob/main/CHANGELOG.md"
 
 [project.scripts]
 forge = "forge.main:main"

--- a/src/forge/__init__.py
+++ b/src/forge/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.0.0"
+__version__ = "1.0.1b1"
 
 # Default values for forge's essential arguments
 DEFAULT_ARG_VALS = {

--- a/src/forge/__init__.py
+++ b/src/forge/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.0.1b1"
+__version__ = "1.0.1"
 
 # Default values for forge's essential arguments
 DEFAULT_ARG_VALS = {

--- a/src/forge/common.py
+++ b/src/forge/common.py
@@ -42,7 +42,7 @@ def check_fleet_id(n, config):
         Filters=[
             {'Name': 'resource-type',
                 'Values': ['fleet']},
-            {'Name': 'value',
+            {'Name': 'tag:forge-name',
                 'Values': [n]}])
     fleet_id = []
     for i in response.get('Tags'):
@@ -85,7 +85,7 @@ def ec2_ip(n, config):
     running_instances = ec2.instances.filter(Filters=[{
         'Name': 'instance-state-name',
         'Values': ['running', 'stopped', 'stopping', 'pending']},
-        {'Name': 'tag:Name',
+        {'Name': 'tag:forge-name',
          'Values': [n]}])
 
     ec2s = []

--- a/src/forge/create.py
+++ b/src/forge/create.py
@@ -391,6 +391,7 @@ def create_template(n, config, task):
     access_vars = user_accessible_vars(config, market=market, task=task)
     tags = [{k: fmt.format(v, **access_vars) for k, v in inner.items()} for inner in tags] if tags else None
     tags = [inner for inner in tags if None not in inner.values()]
+    tags.append({'Key': 'forge-name', 'Value': n})
     specs = {'TagSpecifications': [{'ResourceType': 'instance', 'Tags': tags}]} if tags else {}
 
     valid_tag = [{'Key': 'valid_until', 'Value': datetime.strftime(valid_until, "%Y-%m-%dT%H:%M:%SZ")}]
@@ -563,6 +564,9 @@ def create_fleet(n, config, task):
     fmt = FormatEmpty()
     access_vars = user_accessible_vars(config, market=market, task=task)
     tags = [{k: fmt.format(v, **access_vars) for k, v in inner.items()} for inner in tags] if tags else None
+    tags = [inner for inner in tags if None not in inner.values()]
+    tags.append({'Key': 'forge-name', 'Value': n})
+
     kwargs = {
         'OnDemandOptions': {
             'AllocationStrategy': 'lowest-price'


### PR DESCRIPTION
If the `Name` tag is changed, Forge won't work as it checks that. By changing it to use the `forge-name` tag instead, and automatically setting that, we can ensure all Forge functions work without setting the tags.