### PR TITLE
Fixed Docs Formatting deployed in Github Pages

### DIFF
--- a/docs/cleanup.md
+++ b/docs/cleanup.md
@@ -12,5 +12,6 @@ Forge cleanup will delete all the old [launch templates](https://docs.aws.amazon
 
 ### Parameters
 
-#### Required 
+#### Required
+
 1. `forge_env`

--- a/docs/code_of_conduct.md
+++ b/docs/code_of_conduct.md
@@ -41,6 +41,5 @@ and investigated and will result in a response that is deemed necessary and
 appropriate to the circumstances. Maintainers are obligated to maintain
 confidentiality with regard to the reporter of an incident.
 
-
 This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org),
 [version 1.3.0](https://www.contributor-covenant.org/version/1/3/0/code-of-conduct.html).

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -11,23 +11,25 @@ This step should be needed only once per environment, usually done by someone on
 ### How to Run
 
 1. `forge configure`
-	- Refer to [environmental_yaml](environmental_yaml.md) for more information on each parameter
-	- After completion, the config directory will be given. 
-		- E.g.:
-		```bash
-		$ forge configure
-		Environment Name?: test
-		AWS profile?: aws-test
-		AWS availability zone?: us-east-1a
-		EC2 AMIs?: {'single': ['ami-05fa00d4c63e32376', 30, '/dev/xvda'], 'cluster': ['ami-05fa00d4c63e32376', 30, '/dev/xvda']}
-		AWS Subnet?: subnet-123abc456def789gh
-		AWS key used with EC2?: test
-		AWS Security Group?: sg-abcdefghi12345678
-		Name of Secret for pem key?: forge-pem
-		EC2s to exclude from spot fleet (Optional): *g.*, gd.*, *metal*
-		Tags applied to EC2 and fleet (Optional): [{'Key': 'Name', 'Value': 'n'}, {'Key': 'Application', 'Value': 'name'}, {'Key': 'User', 'Value': 'user'}]
-		The default user_data files. Files are loaded to the config folder (Optional): {'single': 'single.sh', 'cluster': {'master': 'cluster-master.sh', 'worker': 'cluster-worker.sh'}}
-		Additional configs needed for your application (Optional): [{'name': 'pip', 'type': 'list', 'default': [], 'constraints': [], 'error': ''}]
-		Wed Sep 21 13:30:06 2022 -- INFO -- Config directory for /Users/test/envs/forge/lib/python3.6/site-packages/forge/config/test does no exist. Making directory.
-		Wed Sep 21 13:30:06 2022 -- INFO -- Created test config file.
-		```
+
+- Refer to [environmental_yaml](environmental_yaml.md) for more information on each parameter
+- After completion, the config directory will be given.
+- E.g.:
+
+  ```bash
+  $ forge configure
+  Environment Name?: test
+  AWS profile?: aws-test
+  AWS availability zone?: us-east-1a
+  EC2 AMIs?: {'single': ['ami-05fa00d4c63e32376', 30, '/dev/xvda'], 'cluster': ['ami-05fa00d4c63e32376', 30, '/dev/xvda']}
+  AWS Subnet?: subnet-123abc456def789gh
+  AWS key used with EC2?: test
+  AWS Security Group?: sg-abcdefghi12345678
+  Name of Secret for pem key?: forge-pem
+  EC2s to exclude from spot fleet (Optional): *g.*, gd.*, *metal*
+  Tags applied to EC2 and fleet (Optional): [{'Key': 'Name', 'Value': 'n'}, {'Key': 'Application', 'Value': 'name'}, {'Key': 'User', 'Value': 'user'}]
+  The default user_data files. Files are loaded to the config folder (Optional): {'single': 'single.sh', 'cluster': {'master': 'cluster-master.sh', 'worker': 'cluster-worker.sh'}}
+  Additional configs needed for your application (Optional): [{'name': 'pip', 'type': 'list', 'default': [], 'constraints': [], 'error': ''}]
+  Wed Sep 21 13:30:06 2022 -- INFO -- Config directory for /Users/test/envs/forge/lib/python3.6/site-packages/forge/config/test does no exist. Making directory.
+  Wed Sep 21 13:30:06 2022 -- INFO -- Created test config file.
+  ```

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -11,25 +11,23 @@ This step should be needed only once per environment, usually done by someone on
 ### How to Run
 
 1. `forge configure`
-
-- Refer to [environmental_yaml](environmental_yaml.md) for more information on each parameter
-- After completion, the config directory will be given.
-- E.g.:
-
-  ```bash
-  $ forge configure
-  Environment Name?: test
-  AWS profile?: aws-test
-  AWS availability zone?: us-east-1a
-  EC2 AMIs?: {'single': ['ami-05fa00d4c63e32376', 30, '/dev/xvda'], 'cluster': ['ami-05fa00d4c63e32376', 30, '/dev/xvda']}
-  AWS Subnet?: subnet-123abc456def789gh
-  AWS key used with EC2?: test
-  AWS Security Group?: sg-abcdefghi12345678
-  Name of Secret for pem key?: forge-pem
-  EC2s to exclude from spot fleet (Optional): *g.*, gd.*, *metal*
-  Tags applied to EC2 and fleet (Optional): [{'Key': 'Name', 'Value': 'n'}, {'Key': 'Application', 'Value': 'name'}, {'Key': 'User', 'Value': 'user'}]
-  The default user_data files. Files are loaded to the config folder (Optional): {'single': 'single.sh', 'cluster': {'master': 'cluster-master.sh', 'worker': 'cluster-worker.sh'}}
-  Additional configs needed for your application (Optional): [{'name': 'pip', 'type': 'list', 'default': [], 'constraints': [], 'error': ''}]
-  Wed Sep 21 13:30:06 2022 -- INFO -- Config directory for /Users/test/envs/forge/lib/python3.6/site-packages/forge/config/test does no exist. Making directory.
-  Wed Sep 21 13:30:06 2022 -- INFO -- Created test config file.
+	- Refer to [environmental_yaml](environmental_yaml.md) for more information on each parameter
+	- After completion, the config directory will be given. 
+		- E.g.:
+		```bash
+		$ forge configure
+		Environment Name?: test
+		AWS profile?: aws-test
+		AWS availability zone?: us-east-1a
+		EC2 AMIs?: {'single': ['ami-05fa00d4c63e32376', 30, '/dev/xvda'], 'cluster': ['ami-05fa00d4c63e32376', 30, '/dev/xvda']}
+		AWS Subnet?: subnet-123abc456def789gh
+		AWS key used with EC2?: test
+		AWS Security Group?: sg-abcdefghi12345678
+		Name of Secret for pem key?: forge-pem
+		EC2s to exclude from spot fleet (Optional): *g.*, gd.*, *metal*
+		Tags applied to EC2 and fleet (Optional): [{'Key': 'Name', 'Value': 'n'}, {'Key': 'Application', 'Value': 'name'}, {'Key': 'User', 'Value': 'user'}]
+		The default user_data files. Files are loaded to the config folder (Optional): {'single': 'single.sh', 'cluster': {'master': 'cluster-master.sh', 'worker': 'cluster-worker.sh'}}
+		Additional configs needed for your application (Optional): [{'name': 'pip', 'type': 'list', 'default': [], 'constraints': [], 'error': ''}]
+		Wed Sep 21 13:30:06 2022 -- INFO -- Config directory for /Users/test/envs/forge/lib/python3.6/site-packages/forge/config/test does no exist. Making directory.
+		Wed Sep 21 13:30:06 2022 -- INFO -- Created test config file.
   ```

--- a/docs/create.md
+++ b/docs/create.md
@@ -8,23 +8,27 @@ Forge create will create an EC2 fleet using the yaml file you provide. It will b
 
 ### How to Run
 
-1. `forge create` 
-	- A yaml file with all the required parameters can be provided
-	- Each yaml parameter can be overwritten at run time.
-	- E.g. `forge create --yaml /home/docker.yaml --name test123`
+1. `forge create`
+
+- A yaml file with all the required parameters can be provided
+- Each yaml parameter can be overwritten at run time.
+- E.g. `forge create --yaml /home/docker.yaml --name test123`
+
 2. It will take 2-8 minutes to spin up the fleet depending on the service and resources
-3. You will get the IP of the master or single instance once completed 
+3. You will get the IP of the master or single instance once completed
 
 ### Parameters
 
-#### Required 
+#### Required
+
 1. `name`
 2. `service`
 3. `aws_role`
 4. `forge_env`
 5. Either `ram` or `cpu`
 
-#### Optional 
+#### Optional
+
 1. `disk`
 2. `valid_time`
 3. `user_data`

--- a/docs/destroy.md
+++ b/docs/destroy.md
@@ -4,25 +4,29 @@
 
 # Destroy
 
-Forge destroy will terminate the EC2 fleet when the instances are no longer needed. All EC2s and EBS will be terminated to stop incuring cost. 
+Forge destroy will terminate the EC2 fleet when the instances are no longer needed. All EC2s and EBS will be terminated to stop incuring cost.
 
 ### How to Run
 
-1. `forge destroy` 
-	- **ALL** the required parameters must be the same as when `forge create` was ran 
-	- A yaml file with all the parameters can be provided
-	- Each yaml parameter can be overwritten at run time.
-	- E.g. `forge destroy --yaml /home/docker.yaml --name test123`
+1. `forge destroy`
+
+- **ALL** the required parameters must be the same as when `forge create` was ran
+- A yaml file with all the parameters can be provided
+- Each yaml parameter can be overwritten at run time.
+- E.g. `forge destroy --yaml /home/docker.yaml --name test123`
+
 2. It will take about 1 minute depending on the service  
 
 ### Parameters
 
-#### Required 
+#### Required
+
 1. `name`
 2. `service`
 3. `forge_env`
 
-#### Optional 
+#### Optional
+
 1. `market`
 2. `date`
 3. `yaml`

--- a/docs/engine.md
+++ b/docs/engine.md
@@ -4,18 +4,20 @@
 
 # Engine
 
-Forge engine runs [create](create.md), [rsync](rsync.md), and [run](run.md) in order. If `destroy_after_success` and `destroy_after_failure` are set to the default `true`, Forge engine will also destroy the fleet after run. This makes it easy for you to run any job end-to-end with one command. 
+Forge engine runs [create](create.md), [rsync](rsync.md), and [run](run.md) in order. If `destroy_after_success` and `destroy_after_failure` are set to the default `true`, Forge engine will also destroy the fleet after run. This makes it easy for you to run any job end-to-end with one command.
 
 ### How to Run
 
-1. `forge engine` 
-	- A yaml file with all the required parameters can be provided
-	- Each yaml parameter can be overwritten at run time.
-	- E.g. `forge engine --yaml /home/docker.yaml --name test123`
+1. `forge engine`
+
+ - A yaml file with all the required parameters can be provided
+ - Each yaml parameter can be overwritten at run time.
+ - E.g. `forge engine --yaml /home/docker.yaml --name test123`
 
 ### Parameters
 
-#### Required 
+#### Required
+
 1. `name`
 2. `service`
 3. `aws_role`
@@ -24,8 +26,8 @@ Forge engine runs [create](create.md), [rsync](rsync.md), and [run](run.md) in o
 6. `run_cmd`
 7. `rsync_path`
 
+#### Optional
 
-#### Optional 
 1. `disk`
 2. `valid_time`
 3. `user_data`

--- a/docs/environmental_yaml.md
+++ b/docs/environmental_yaml.md
@@ -5,113 +5,136 @@
 
 # Environmental Yaml (setup by admins)
 
-Each forge job requires an environment created. This includes an environment yaml and the default user data scripts (optional). 
+Each forge job requires an environment created. This includes an environment yaml and the default user data scripts (optional).
 
 ## Setup
-https://github.com/carsdotcom/cars-forge/blob/main/examples/env_yaml_example/example.yaml
+
+<https://github.com/carsdotcom/cars-forge/blob/main/examples/env_yaml_example/example.yaml>
+
 ### Option 1: Copy files to the config folder
 
 1. Referring to the [example yaml](https://github.com/carsdotcom/cars-forge/blob/main/examples/env_yaml_example/example.yaml), create your environment yaml file.
 2. Create your default user data script (optional). An example can be found [here](https://github.com/carsdotcom/cars-forge/blob/main/examples/env_yaml_example/single.sh).
-	- In the `user_data` parameter in the environment yaml, you can specify what the default user data script should be if the user does not provide one.
-	- `echo "$(cat /root/.ssh/authorized_keys | sed 's/^.*ssh-rsa/ssh-rsa/')" > /root/.ssh/authorized_keys` is needed in all user data scripts because Forge runs all commands as root.
+
+- In the `user_data` parameter in the environment yaml, you can specify what the default user data script should be if the user does not provide one.
+- `echo "$(cat /root/.ssh/authorized_keys | sed 's/^.*ssh-rsa/ssh-rsa/')" > /root/.ssh/authorized_keys` is needed in all user data scripts because Forge runs all commands as root.
+
 3. Run `forge configure -h`
-	- This will output the location of the configure folder.
-	- Example: `Configure env yaml and place it in /home/ec2-user/.local/lib/python3.7/site-packages/forge/config/`
+
+- This will output the location of the configure folder.
+- Example: `Configure env yaml and place it in /home/ec2-user/.local/lib/python3.7/site-packages/forge/config/`
+
 4. Create a new folder under the config folder.
-	- E.g.
-	```bash
-	mkdir -p /home/ec2-user/.local/lib/python3.7/site-packages/forge/config/example`
-	```
+
+- E.g.
+
+ ```bash
+ mkdir -p /home/ec2-user/.local/lib/python3.7/site-packages/forge/config/example`
+ ```
+
 5. Copy your environment yaml and user data script to the new folder.
 
-### Option 2: Use forge configure 
+### Option 2: Use forge configure
+
 1. Run `forge configure` and fill in all the parameters.
 2. Create your default user data script (optional). An example can be found [here](https://github.com/carsdotcom/cars-forge/blob/main/examples/env_yaml_example/single.sh).
-	- In the `user_data` parameter in the environment yaml, you can specify what the default user data script should be if one is not provided.
-	- `echo "$(cat /root/.ssh/authorized_keys | sed 's/^.*ssh-rsa/ssh-rsa/')" > /root/.ssh/authorized_keys` is needed in all user data scripts because Forge runs all commands as root.
+
+- In the `user_data` parameter in the environment yaml, you can specify what the default user data script should be if one is not provided.
+- `echo "$(cat /root/.ssh/authorized_keys | sed 's/^.*ssh-rsa/ssh-rsa/')" > /root/.ssh/authorized_keys` is needed in all user data scripts because Forge runs all commands as root.
+
 3. Run `forge configure -h`
-	- This will output the location of the configure folder.
-	- Example: `Configure env yaml and place it in /home/ec2-user/.local/lib/python3.7/site-packages/forge/config/`
+
+- This will output the location of the configure folder.
+- Example: `Configure env yaml and place it in /home/ec2-user/.local/lib/python3.7/site-packages/forge/config/`
+
 4. Locate the environment under the config folder. The folder name will be the same as the `name` you used when you ran `forge configure`.
 5. Copy your user data script to the new folder.
 
 ## Environmental parameters (setup by admins)
 
 - **additional_config** - Additional configuration options allowed in user config files
-	- Needs four parameters: 
-		- name: name of the parameter
-		- type: data type
-		- default: default value if one isn't given.
-		- constraints: options they must choose
-		- error: error message if a given value is the wrong type or not within constraints
-	- E.g.
-    ```yaml
-	additional_config:
-	  - name: pip
-	    type: list
-	    default: []
-	    constraints: []
-	    error: ""
-	  - name: version
-	    type: float
-	    default: 2.3
-	    constraints: [2.3, 3.0, 3.1]
-	    error: "Invalid Spark version. Only 2.3, 3.0, and 3.1 are supported."
-    ```
+  - Needs four parameters:
+    - name: name of the parameter
+    - type: data type
+    - default: default value if one isn't given.
+    - constraints: options they must choose
+    - error: error message if a given value is the wrong type or not within constraints
+  - E.g.
+
+  ```yaml
+    additional_config:
+    name: pip
+      type: list
+      default: []
+      constraints: []
+      error: ""
+    name: version
+      type: float
+      default: 2.3
+      constraints: [2.3, 3.0, 3.1]
+      error: "Invalid Spark version. Only 2.3, 3.0, and 3.1 are supported."
+  ```
+
 - **aws_az** - The [AWS availability zone](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html) where Forge will create the EC2 instance. Currently, Forge can run only in one AZ
 - **aws_profile** - [AWS CLI profile](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html) to use
 - **aws_security_group** - [AWS Security Group](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-security-groups.html) for the instance
-- **aws_subnet** - [AWS subnet](https://docs.aws.amazon.com/vpc/latest/userguide/configure-subnets.html) where the EC2s will run 
+- **aws_subnet** - [AWS subnet](https://docs.aws.amazon.com/vpc/latest/userguide/configure-subnets.html) where the EC2s will run
 - **default_ratio** - Override the default ratio of RAM to CPU if the user does not provide one. Must be a list of the minimum and maximum.
-	- default is [8, 8]
+  - default is [8, 8]
 - **ec2_amis** - A dictionary of dictionaries to store [AMI](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html) info.
-	- Needs three parameters: 
-			- ami id
-			- minimum disk size
-			- [device name](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/device_naming.html)
-	- E.g.
-	```yaml
-	ec2_amis:
-	  single:
-	    ami: ami-abcdefghi12345678
-	    disk: 30
-	    disk_device_name: /dev/sda1
-	  cluster:
-	    ami: ami-12345678abcdefghi
-	    disk: 30
-	    disk_device_name: /dev/xvda
-	  single_gpu:
-	    ami: ami-abcdefghi00000000
-	    disk: 90
-	    disk_device_name: /dev/sda1
-	```
+  - Needs three parameters:
+  - ami id
+  - minimum disk size
+  - [device name](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/device_naming.html)
+  - E.g.
+
+```yaml
+ ec2_amis:
+   single:
+     ami: ami-abcdefghi12345678
+     disk: 30
+     disk_device_name: /dev/sda1
+   cluster:
+     ami: ami-12345678abcdefghi
+     disk: 30
+     disk_device_name: /dev/xvda
+   single_gpu:
+     ami: ami-abcdefghi00000000
+     disk: 90
+     disk_device_name: /dev/sda1
+```
+
 - **ec2_key** - The [key pair](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html) name used to ssh into the EC2. This will be stored in `forge_pem_secret`
 - **ec2_max** - Override the default maximum amount of RAM a single instance can have. The default is 768.
 - **excluded_ec2s** - List of EC2 types to not consider when creating instances. You can use strings with one or more wild cards, represented by an asterisk (\*)
-	- E.g.
-	```yaml
-	excluded_ec2s: ["*g.*", "gd.*", "*metal*", "g4ad*"]
-	```
+  - E.g.
+
+ ```yaml
+ excluded_ec2s: ["*g.*", "gd.*", "*metal*", "g4ad*"]
+ ```
+
 - **forge_env** - Name of the Forge environment. The user will refer to this in their yaml.
 - **forge_pem_secret** - The secret name where the `ec2_key` is stored
-- **tags** - [Tags](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html) to apply to instances created by Forge. Follows the AWS tag format. 
-	- Forge also exposes all string, numeric, and some extra variables from the combined user and environmental configs that will be replaced at runtime by the matching values (e.g. `{name}` for job name, `{date}` for job date, etc.) See the [variables](variables.md) page for more details.
-	- E.g.
-	```yaml
-	tags:
-	  - Key: "Name"
-	    Value: "{name}-{market}-{task}-{date}"
-	  - Key: "Application"
-    	Value: "{name}"
-	  - Key: "User"
-	    Value: "{user}"
+- **tags** - [Tags](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html) to apply to instances created by Forge. Follows the AWS tag format.
+  - Forge also exposes all string, numeric, and some extra variables from the combined user and environmental configs that will be replaced at runtime by the matching values (e.g. `{name}` for job name, `{date}` for job date, etc.) See the [variables](variables.md) page for more details.
+  - E.g.
+
+ ```yaml
+ tags:
+   - Key: "Name"
+     Value: "{name}-{market}-{task}-{date}"
+   - Key: "Application"
+     Value: "{name}"
+   - Key: "User"
+     Value: "{user}"
   ```
+
 - **user_data** - Paths to the default [user_data](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html) scripts. Can be overwritten by the user.
-	- Forge also exposes all string, numeric, and some extra variables from the combined user and environmental configs that will be replaced at runtime by the matching values (e.g. `{name}` for job name, `{date}` for job date, etc.) See the [variables](variables.md) page for more details.
-	- **Note** Forge uses the root user to rsync and run. One way to allow this is to add the below to the user data.
-	```bash
-	#!/bin/bash
-	set -x
-	echo "$(cat /root/.ssh/authorized_keys | sed 's/^.*ssh-rsa/ssh-rsa/')" > /root/.ssh/authorized_keys
-	```
+  - Forge also exposes all string, numeric, and some extra variables from the combined user and environmental configs that will be replaced at runtime by the matching values (e.g. `{name}` for job name, `{date}` for job date, etc.) See the [variables](variables.md) page for more details.
+  - **Note** Forge uses the root user to rsync and run. One way to allow this is to add the below to the user data.
+
+ ```bash
+ #!/bin/bash
+ set -x
+ echo "$(cat /root/.ssh/authorized_keys | sed 's/^.*ssh-rsa/ssh-rsa/')" > /root/.ssh/authorized_keys
+ ```

--- a/docs/example.md
+++ b/docs/example.md
@@ -4,62 +4,84 @@
 
 # Example for single EC2
 
-- Below we will walk through an example of how to use Forge to set up a python jupyter notebook. 
+- Below we will walk through an example of how to use Forge to set up a python jupyter notebook.
 
 ## [Setup](setup.md)
 
 ### AWS Setup
 
-1. [Install](install.md) Forge on your computer or an EC2. 
+1. [Install](install.md) Forge on your computer or an EC2.
 2. In AWS, create a role that the Forge EC2 will use. The name of the role should be "forge-{aws_role}-{forge-env}".
-	- Give this role any permission you need to complete the job. 
-	- You should give this role ec2:Describe* permissions so the worker can attach to the master.
-	- Select EC2 as the trusted AWS service
-	- For this example, we will use `forge-test-example`.
+
+- Give this role any permission you need to complete the job.
+- You should give this role ec2:Describe* permissions so the worker can attach to the master.
+- Select EC2 as the trusted AWS service
+- For this example, we will use `forge-test-example`.
+
 3. Create a new user, group, or role that will run the Forge commands.
-	- An example IAM policy can be found [here](https://github.com/carsdotcom/cars-forge/blob/main/examples/forge_user_IAM). This has the minimum permission Forge needs to run but can be modified.
-	- Replace `ACCOUNT_ID` with your AWS account id. 
-	- Replace the IAM names if you changed them. 
-	- For this example, we will create a user called `forge-example`.
-		- When creating the user, make sure to select Access key and download the keys. 
+
+- An example IAM policy can be found [here](https://github.com/carsdotcom/cars-forge/blob/main/examples/forge_user_IAM). This has the minimum permission Forge needs to run but can be modified.
+- Replace `ACCOUNT_ID` with your AWS account id.
+- Replace the IAM names if you changed them.
+- For this example, we will create a user called `forge-example`.
+- When creating the user, make sure to select Access key and download the keys.
+
 4. If you created a user, you need to setup the profile on the computer you will be running forge.
-	- `aws configure --profile forge-example`
-	- Enter in the Access key ID and then Secret access key
+
+- `aws configure --profile forge-example`
+- Enter in the Access key ID and then Secret access key
+
 5. [Create new key pair](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/create-key-pairs.html)
-	- For this example, we will name it `test`.
+
+- For this example, we will name it `test`.
+
 6. Encode the key pair with base64. You can use [this site](https://www.base64encode.org/).
 7. Create a new secret in [Secrets Manager](https://aws.amazon.com/secrets-manager/). The secret type is `Other type of secret` The secret name will be used in the [environment yaml](environmental_yaml.md) in the parameter "forge_pem_secret".
-	- The secret key is `encoded_pem` and the value is the base64 encrypted key pair.
-	- For this example we will name the secret `forge-pem`
+
+- The secret key is `encoded_pem` and the value is the base64 encrypted key pair.
+- For this example we will name the secret `forge-pem`
 
 ### [Environment Yaml](environmental_yaml.md)
 
 1. Referring to the [example yaml](https://github.com/carsdotcom/cars-forge/blob/main/examples/env_yaml_example/example.yaml), create your environment yaml file. For more information about the environment yaml, please refer to [environmental_yaml](environmental_yaml.md).
-	- The tags, excluded_ec2s, secret name, and user data are prefilled with examples. All of the above and be used as is or updated.
-	- The AWS AZ, AMI, aws_subnet and aws_security_group need to be updated for your environment.
+
+- The tags, excluded_ec2s, secret name, and user data are prefilled with examples. All of the above and be used as is or updated.
+- The AWS AZ, AMI, aws_subnet and aws_security_group need to be updated for your environment.
+
 2. Create your default user data script (optional). An example can be found [here](https://github.com/carsdotcom/cars-forge/blob/main/examples/env_yaml_example/single.sh).
-	- In the `user_data` parameter in the environment yaml, you can specify what the default user data script should be if the user does not provide one.
-	- `echo "$(cat /root/.ssh/authorized_keys | sed 's/^.*ssh-rsa/ssh-rsa/')" > /root/.ssh/authorized_keys` is needed in all user data scripts because Forge runs all commands as root.
+
+- In the `user_data` parameter in the environment yaml, you can specify what the default user data script should be if the user does not provide one.
+- `echo "$(cat /root/.ssh/authorized_keys | sed 's/^.*ssh-rsa/ssh-rsa/')" > /root/.ssh/authorized_keys` is needed in all user data scripts because Forge runs all commands as root.
+
 3. Run `forge configure -h`
-	- This will output the location of the configure folder.
-	- Example: `Configure env yaml and place it in /home/ec2-user/.local/lib/python3.7/site-packages/forge/config/`
+
+- This will output the location of the configure folder.
+- Example: `Configure env yaml and place it in /home/ec2-user/.local/lib/python3.7/site-packages/forge/config/`
+
 4. Create a new folder under the config folder.
-	- E.g.
-	```bash
-	mkdir -p /home/ec2-user/.local/lib/python3.7/site-packages/forge/config/example
-	```
+
+- E.g.
+
+ ```bash
+ mkdir -p /home/ec2-user/.local/lib/python3.7/site-packages/forge/config/example
+ ```
+
 5. Copy your environment yaml and user data script to the new folder.
-	- E.g.
-	```bash
-	cp example.yaml single.sh /home/ec2-user/.local/lib/python3.7/site-packages/forge/config/example/
-	```
+
+- E.g.
+
+ ```bash
+ cp example.yaml single.sh /home/ec2-user/.local/lib/python3.7/site-packages/forge/config/example/
+ ```
 
 ## Run Example
 
 1. In the Git repo, you will find an [example folder](https://github.com/carsdotcom/cars-forge/tree/main/examples/single_example) we will be using for this example. It included the yaml, user data script, and run script. For more information about the user yaml, please see the [yaml.md](yaml.md).
-	- The single EC2 instance will have 16 or 32GB of RAM.
-	- It will only stay up for 3 hours.
-	- If there is a failure or if you cancel out of jupyter, the instance will be killed.
+
+- The single EC2 instance will have 16 or 32GB of RAM.
+- It will only stay up for 3 hours.
+- If there is a failure or if you cancel out of jupyter, the instance will be killed.
+
 2. From inside the single_example folder, run `forge create --yaml single_example.yaml --user_data single_ud.sh`. Once the instance is created the hourly price will be printed.
 3. Run `forge rsync --yaml single_example.yaml`
 4. Run `forge run --yaml single_example.yaml`

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,15 +1,18 @@
 ### Purpose
+
 Forge is a Python-based command-line tool that starts a single or cluster of EC2 instances, and runs the required scripts on these instances. Forge can be used by anyone to create their own environment where they can do anything like develop products, analyze data, host interactive dashboards, or run production workloads on terabytes of RAM. Forge gives you complete flexibility while making it easy to run everything on spot EC2 instances saving you up to 90% compared to on-demand instances.
 
 ### Features
- - Create a single or cluster of EC2 instances of any size using spot or on-demand pricing 
- - Rsync files to the instance(s)
- - Run a script on the instance(s)
- - Destroy your EC2 fleet
- - SSH into your master or single instance
- - Start and Stop your on-demand instance(s)
+
+- Create a single or cluster of EC2 instances of any size using spot or on-demand pricing
+- Rsync files to the instance(s)
+- Run a script on the instance(s)
+- Destroy your EC2 fleet
+- SSH into your master or single instance
+- Start and Stop your on-demand instance(s)
 
 ### Getting Started
+
 - [Install](install.md)
 - [Setup](setup.md)
 - [Example](example.md)
@@ -17,13 +20,14 @@ Forge is a Python-based command-line tool that starts a single or cluster of EC2
 - [Yaml](yaml.md)
 
 ### Forge Commands
- - [Cleanup](cleanup.md)
- - [Configure](configure.md)
- - [Create](create.md)
- - [Destroy](destroy.md)
- - [Engine](engine.md)
- - [Rsync](rsync.md)
- - [Run](run.md)
- - [Ssh](ssh.md)
- - [Start](start.md)
- - [Stop](stop.md)
+
+- [Cleanup](cleanup.md)
+- [Configure](configure.md)
+- [Create](create.md)
+- [Destroy](destroy.md)
+- [Engine](engine.md)
+- [Rsync](rsync.md)
+- [Run](run.md)
+- [Ssh](ssh.md)
+- [Start](start.md)
+- [Stop](stop.md)

--- a/docs/install.md
+++ b/docs/install.md
@@ -9,6 +9,7 @@ Forge requires Python version 3.7 or later to run.
 ### Pip Install
 
 Forge can be installed via pip.
+
 ```
 pip (or pip3) install cars-forge
 ```
@@ -17,10 +18,13 @@ pip (or pip3) install cars-forge
 
 To install from source, copy or clone the repository onto your machine. Then, navigate
 to the root of the project and install.
+
 ```
 pip (or pip3) install .
 ```
+
 If you do not have proper access on the machine you are using, Forge can be installed locally with the following command.
+
 ```
 pip (or pip3) install . --user
 ```
@@ -28,6 +32,7 @@ pip (or pip3) install . --user
 # Executing
 
 Once it is installed, you will be able to use Forge from anywhere on the system with the `forge` command.
+
 ```
 forge
 ```

--- a/docs/rsync.md
+++ b/docs/rsync.md
@@ -8,23 +8,28 @@ Forge rsync makes it simple for you to copy a folder or file from local to the f
 
 ### How to Run
 
-1. `forge rsync` 
-	- **ALL** the parameters must be the same as when `forge create` was ran
-	- A yaml file with all the required parameters can be provided
-	- Each yaml parameter can be overwritten at run time.
-	- E.g. `forge rsync --yaml /home/docker.yaml --rsync_path /home/test/run.sh`
+1. `forge rsync`
+
+- **ALL** the parameters must be the same as when `forge create` was ran
+- A yaml file with all the required parameters can be provided
+- Each yaml parameter can be overwritten at run time.
+- E.g. `forge rsync --yaml /home/docker.yaml --rsync_path /home/test/run.sh`
+
 2. By default, the folder or file will be moved to /root/ of the single or master instance.
-	- The `--all` flag will copy the folder of file to all of the instances in the cluster
+
+- The `--all` flag will copy the folder of file to all of the instances in the cluster
 
 ### Parameters
 
-#### Required 
+#### Required
+
 1. `name`
 2. `service`
 3. `forge_env`
 4. `rsync_path`
 
-#### Optional 
+#### Optional
+
 1. `market`
 2. `date`
 3. `all`

--- a/docs/run.md
+++ b/docs/run.md
@@ -8,25 +8,30 @@ Forge run will run any script on the single or master instance. You need to [rsy
 
 ### How to Run
 
-1. `forge run` 
-	- **ALL** the parameters must be the same as when `forge create` was ran
-	- A yaml file with all the required parameters can be provided
-	- Each yaml parameter can be overwritten at run time.
-	- Forge also exposes all string, numeric, and some extra variables from the combined user and environmental configs that will be replaced at runtime by the matching values (e.g. `{name}` for job name, `{date}` for job date, etc.) See the [variables](variables.md) page for more details.
-    - If you are overriding the `run_cmd` parameter at run time, you must enclose it in quotes to prevent any argument misinterpretation.
-	- E.g. `forge run --yaml /home/docker.yaml --run_cmd '/home/test/run.sh ${date} ${env}'`
+1. `forge run`
+
+- **ALL** the parameters must be the same as when `forge create` was ran
+- A yaml file with all the required parameters can be provided
+- Each yaml parameter can be overwritten at run time.
+- Forge also exposes all string, numeric, and some extra variables from the combined user and environmental configs that will be replaced at runtime by the matching values (e.g. `{name}` for job name, `{date}` for job date, etc.) See the [variables](variables.md) page for more details.
+  - If you are overriding the `run_cmd` parameter at run time, you must enclose it in quotes to prevent any argument misinterpretation.
+- E.g. `forge run --yaml /home/docker.yaml --run_cmd '/home/test/run.sh ${date} ${env}'`
+
 2. By default, the command will run on the single or master instance.
-	- The `--all` flag will run the command on all of the instances in the cluster
+
+- The `--all` flag will run the command on all of the instances in the cluster
 
 ### Parameters
 
-#### Required 
+#### Required
+
 1. `name`
 2. `service`
 3. `forge_env`
 4. `run_cmd`
 
-#### Optional 
+#### Optional
+
 1. `market`
 2. `date`
 3. `all`

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -4,23 +4,31 @@
 
 # Setup
 
-1. [Install](install.md) Forge on your computer or an EC2. 
+1. [Install](install.md) Forge on your computer or an EC2.
 2. In AWS, create a role that the Forge EC2 will use. The name of the role should be "forge-{aws_role}-{forge-env}".
-	- Give this role any permission you need to complete the job. 
-	- You should give this role ec2:Describe* permissions so the worker can attach to the master. 
-	- Select EC2 as the trusted AWS service
+
+- Give this role any permission you need to complete the job.
+- You should give this role ec2:Describe* permissions so the worker can attach to the master.
+- Select EC2 as the trusted AWS service
+
 3. Create a new user, group, or role that will run the Forge commands.
-	- An example IAM policy can be found [here](https://github.com/carsdotcom/cars-forge/blob/main/examples/forge_user_IAM). This has the minimum permission Forge needs to run but can be modified. 
-		- Replace `ACCOUNT_ID` with your AWS account id. 
-		- Replace the IAM names if you changed them. 
-	- If you are creating a user, make sure to select Access key and download the keys. 
+
+- An example IAM policy can be found [here](https://github.com/carsdotcom/cars-forge/blob/main/examples/forge_user_IAM). This has the minimum permission Forge needs to run but can be modified.
+- Replace `ACCOUNT_ID` with your AWS account id.
+- Replace the IAM names if you changed them.
+- If you are creating a user, make sure to select Access key and download the keys.
+
 4. If you created a user, you need to setup the profile on the computer you will be running forge.
-	- `aws configure --profile forge-test`
-	- Enter in the Access key ID and then Secret access key 
+
+- `aws configure --profile forge-test`
+- Enter in the Access key ID and then Secret access key
+
 5. [Create new key pair](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/create-key-pairs.html)
 6. Encode the key pair with base64. You can use [this site](https://www.base64encode.org/).
 7. Create a new secret in [Secrets Manager](https://aws.amazon.com/secrets-manager/). The secret type is `Other type of secret` The secret name will be used in the [environment yaml](environmental_yaml.md) in the parameter "forge_pem_secret".
-	- The secret key is `encoded_pem` and the value is the base64 encrypted key pair.
+
+- The secret key is `encoded_pem` and the value is the base64 encrypted key pair.
+
 8. Set up the forge environment using [environment yaml](environmental_yaml.md). There are two options to choose from.
 9. Create a user yaml. An example can be found [here](https://github.com/carsdotcom/cars-forge/blob/main/examples/single_example/single_example.yaml)
 10. Test by running `forge create --yaml example.yaml`. Once successful, destroy the cluster by running `forge destroy --yaml example.yaml`.

--- a/docs/ssh.md
+++ b/docs/ssh.md
@@ -4,24 +4,28 @@
 
 # SSH
 
-Forge will SSH you into your single or master instance. Forge will pull the pem file from secret manager. 
+Forge will SSH you into your single or master instance. Forge will pull the pem file from secret manager.
 
 ### How to Run
 
-1. `forge ssh` 
-	- **ALL** the parameters must be the same as when forge create was ran
-	- A yaml file with all the required parameters can be provided
-	- Each yaml parameter can be overwritten at run time.
-	- E.g. `forge ssh --yaml /home/docker.yaml --name test123`
+1. `forge ssh`
+
+- **ALL** the parameters must be the same as when forge create was ran
+- A yaml file with all the required parameters can be provided
+- Each yaml parameter can be overwritten at run time.
+- E.g. `forge ssh --yaml /home/docker.yaml --name test123`
+
 2. You will be SSHed in as the root user to the /root folder.
 
 ### Parameters
 
-#### Required 
+#### Required
+
 1. `name`
 2. `service`
 3. `forge_env`
 
-#### Optional 
+#### Optional
+
 1. `market`
 2. `date`

--- a/docs/start.md
+++ b/docs/start.md
@@ -8,20 +8,24 @@ Forge start will start a stopped on-demand instance.
 
 ### How to Run
 
-1. `forge start` 
-	- **ALL** the parameters must be the same as when forge create was ran
-	- A yaml file with all the required parameters can be provided
-	- Each yaml parameter can be overwritten at run time.
-	- E.g. `forge start --yaml /home/docker.yaml --market on-demand`
+1. `forge start`
+
+- **ALL** the parameters must be the same as when forge create was ran
+  - A yaml file with all the required parameters can be provided
+  - Each yaml parameter can be overwritten at run time.
+  - E.g. `forge start --yaml /home/docker.yaml --market on-demand`
+
 2. Works only on on-demand instances.
 
 ### Parameters
 
-#### Required 
+#### Required
+
 1. `name`
 2. `service`
 3. `forge_env`
 
-#### Optional 
+#### Optional
+
 1. `market`
 2. `date`

--- a/docs/stop.md
+++ b/docs/stop.md
@@ -8,20 +8,24 @@ Forge stop will stop an on-demand instances. The instance itself will no longer 
 
 ### How to Run
 
-1. `forge stop` 
-	- **ALL** the parameters must be the same as when forge create was ran
-	- A yaml file with all the required parameters can be provided
-	- Each yaml parameter can be over written at run time.
-	- E.g. `forge stop --yaml /home/docker.yaml --market on-demand`
-2. Works only on on-demand instances 
+1. `forge stop`
+
+- **ALL** the parameters must be the same as when forge create was ran
+- A yaml file with all the required parameters can be provided
+- Each yaml parameter can be over written at run time.
+- E.g. `forge stop --yaml /home/docker.yaml --market on-demand`
+
+2. Works only on on-demand instances
 
 ### Parameters
 
-#### Required 
+#### Required
+
 1. `name`
 2. `service`
 3. `forge_env`
 
-#### Optional 
+#### Optional
+
 1. `market`
 2. `date`

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -4,25 +4,31 @@
 
 # Variables
 
-Forge exposes all string and numeric (ints and floats) variables from the combined user and environmental configs, some extra variables, and any environment-specific additional variables (regardless of type) to be used in `tags` (defined in the environment yaml), `run_cmd`, and `user_data` configs. 
+Forge exposes all string and numeric (ints and floats) variables from the combined user and environmental configs, some extra variables, and any environment-specific additional variables (regardless of type) to be used in `tags` (defined in the environment yaml), `run_cmd`, and `user_data` configs.
 
 - E.g.
-	- `tags`
-		```yaml
-		tags:
-		  - Key: "Name"
-		    Value: "{name}-{market}-{task}-{date}"
-		```
-	- `user_data`
-		```bash
-		aws ec2 describe-instances --filters "Name=tag:Name,Values={name}-{market_master}-{service}-master-{date}"
-		```
-	- `run_cmd`
-		```yaml
-		run_cmd: single_run.sh {ip} carsforge/jupyter-example:latest
-		```
+  - `tags`
 
-### List of available variables:
+  ```yaml
+  tags:
+    - Key: "Name"
+      Value: "{name}-{market}-{task}-{date}"
+  ```
+
+  - `user_data`
+
+  ```bash
+  aws ec2 describe-instances --filters "Name=tag:Name,Values={name}-{market_master}-{service}-master-{date}"
+  ```
+
+  - `run_cmd`
+
+  ```yaml
+  run_cmd: single_run.sh {ip} carsforge/jupyter-example:latest
+  ```
+
+### List of available variables
+
 - **aws_az**
 - **aws_profile**
 - **aws_security_group**

--- a/docs/yaml.md
+++ b/docs/yaml.md
@@ -8,73 +8,89 @@ Each forge command certain parameters. A yaml file with all the parameters can b
 
 - **aws_role** - The IAM role forge-*aws_role*-*forge_env* will be attached to the EC2s spun up by Forge.
 - **cpu** - Minimum amount of vCPU required. Can be a range e.g. [2, 4].
-    - If using a cluster, you must specify both the master and worker. Master first, worker second. 
+  - If using a cluster, you must specify both the master and worker. Master first, worker second.
+
       ```yaml
       cpu:
       - 2, 4
       - 32, 64
       ```
+
     - If using single, only 1 value is needed.
+
       ```yaml
       cpu:
         - 2,4
       ```
+
     - If running via the command line, a range of values is passed as: ``--cpu [[1,2]]``.
     - If cpu is not provided, ram is needed. cpu is calculated using ram and ram-to-cpu ratio (default is 8)
-- **date** - An optional parameter. Can be used in the run_cmd or name. 
+- **date** - An optional parameter. Can be used in the run_cmd or name.
 - **destroy_after_failure** - Runs `forge destroy` if `forge create`, `forge engine`, or `forge run` has an unsuccessful run. True or False. Default is True
-    - If running via the command line use `no_destroy_after_failure` 
+  - If running via the command line use `no_destroy_after_failure`
 - **destroy_after_success** - Runs `forge destroy` if `forge engine` or `forge run` has a successful run. True or False. Default is True
-    - If running via the command line use `no_destroy_after_success` 
+  - If running via the command line use `no_destroy_after_success`
 - **disk** - Disk size of the instance. Default is set up by the admin depending on the ami.
 - **forge_env** - The environment that corresponds with the environment yaml created by the admin. This houses all the AWS information that is required but won't change much between each run.
 - **gpu_flag** - Starts an instance with a GPU. Can be used only with docker. True or False. Default is False
 - **log_level** - Override the default logging level (`info`). Valid options are: `debug`, `info`, `warning`, or `error`.
 - **market** - Start the instances as spot or on-demand. The default is spot.
-    - If using a cluster, you must specify both the master and worker. Master first, worker second.
+  - If using a cluster, you must specify both the master and worker. Master first, worker second.
+
       ```yaml
       market:
         - on-demand
         - spot
       ```
-    - If using single, only 1 value is needed.
+
+  - If using single, only 1 value is needed.
+
       ```yaml
       market: spot
       ```
-    - If running via the command line, a range of values is passed as: ``--market on-demand spot``.
+
+  - If running via the command line, a range of values is passed as: ``--market on-demand spot``.
 - **name** - Name of the instance/cluster
-- **ram** - Minimum amount of RAM required. Can be a range e.g. [16, 32]. 
-    - If using a cluster, you must specify both the master and worker. Master first, worker second.
+- **ram** - Minimum amount of RAM required. Can be a range e.g. [16, 32].
+  - If using a cluster, you must specify both the master and worker. Master first, worker second.
+
       ```yaml
       ram:
         - 8
         - 256, 512
       ```
-    - If using single, only 1 value is needed.
+
+  - If using single, only 1 value is needed.
+
       ```yaml
       ram:
         - 32
       ```
-    - If running via the command line, a range of values is passed as: ``--ram [[8,16][512]]``.
-    - If ram is not provided, cpu is needed. ram is calculated using cpu and ram-to-cpu ratio (default is 8)
+
+  - If running via the command line, a range of values is passed as: ``--ram [[8,16][512]]``.
+  - If ram is not provided, cpu is needed. ram is calculated using cpu and ram-to-cpu ratio (default is 8)
 - **ratio** - the ratio of ram-to-cpu. The default is 8 but can be overwritten.
-    - If using a cluster, you must specify both the master and worker. Master first, worker second. 
+  - If using a cluster, you must specify both the master and worker. Master first, worker second.
+
       ```yaml
       ratio:
         - 8
         - 6,8
       ```
-    - If using single, only 1 value is needed.
+
+  - If using single, only 1 value is needed.
+
       ```yaml
       ratio:
         - 8
       ```
-    - If running via the command line, a range of values is passed as: ``--ratio [[8][6,8]]``.
-- **rsync_path** - The folder or file that will be copied to the instance. Folder or file will be written to the /root directory. 
-    - Use the `--all` flag to rsync the file or folder to all the instances in a cluster.
+
+  - If running via the command line, a range of values is passed as: ``--ratio [[8][6,8]]``.
+- **rsync_path** - The folder or file that will be copied to the instance. Folder or file will be written to the /root directory.
+  - Use the `--all` flag to rsync the file or folder to all the instances in a cluster.
 - **run_cmd** - The command that will be ran on the master or single instance. The path is relative to `rsync_path`. Any arguments will be passed to the script as is. Special variables `{env}`, `{date}`, and `{ip}` are available and will be replaced at runtime by the instance values. All commands will run as the root user.
-    - Use the `--all` flag to run the script on all the instances in a cluster.
-    - E.g. `run_cmd: scripts/run.sh {env} {date} {ip}`
+  - Use the `--all` flag to run the script on all the instances in a cluster.
+  - E.g. `run_cmd: scripts/run.sh {env} {date} {ip}`
 - **service** - `cluster` or `single`
 - **user_data** - Custom script passed to instance. Will be run only once when the instance starts up.
 - **valid_time** - How many hours the fleet will stay up. After this time, all EC2s will be destroyed. The default is 8.


### PR DESCRIPTION
## Description
The code was not linted properly which was showing abrupt results in the deployed github pages version of the docs.

---
## Issue Ticket Number
Fixes #4 

---
## Implemented Solution
On fixing the stylistic errors in the docs using a code linter, all the documents now show up correctly in the github pages version as well. Thus, fixing the issue.