### PR TITLE
Added more clear SSH error message for improper credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - **GitHub** - Add step to create GitHub release after uploading to PYPI.
 - **GitHub** - Update action to build and publish package only when version is bumped.
 - **Forge** - Added automatic tag `forge-name` to allow `Name` tag to be changed.
-
+- **Forge** - Added error to show when SSH credentials are invalid
 
 ## [1.0.0] - 2022-09-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 - **Common** - Move EC2 pricing calls to single function in `common.py`.
 - **Readme** - Added new badges to the Readme
+- **Forge** - Added error to show when SSH credentials are invalid
 
 
 ## [1.0.1] - 2022-09-28
@@ -26,7 +27,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - **GitHub** - Add step to create GitHub release after uploading to PYPI.
 - **GitHub** - Update action to build and publish package only when version is bumped.
 - **Forge** - Added automatic tag `forge-name` to allow `Name` tag to be changed.
-- **Forge** - Added error to show when SSH credentials are invalid
 
 ## [1.0.0] - 2022-09-27
 

--- a/src/forge/ssh.py
+++ b/src/forge/ssh.py
@@ -67,7 +67,8 @@ def ssh(config):
         try:
             subprocess.run(shlex.split(cmd), check=True, universal_newlines=True)
         except subprocess.CalledProcessError as exc:
-            logger.error(
-                'SSH failed with error code %d: %s', exc.returncode, exc.cmd
-            )
+            if exc.returncode == 142:
+                logger.error('Missing proper SSH credentials to connect. Please check your user_data and AMI.')
+            else:
+                logger.error('SSH failed with error code %d: %s', exc.returncode, exc.cmd)
             sys.exit(exc.returncode)

--- a/src/forge/ssh.py
+++ b/src/forge/ssh.py
@@ -68,7 +68,7 @@ def ssh(config):
             subprocess.run(shlex.split(cmd), check=True, universal_newlines=True)
         except subprocess.CalledProcessError as exc:
             if exc.returncode == 142:
-                logger.error('Missing proper SSH credentials to connect. Please check your user_data and AMI.')
+                logger.error('Missing proper SSH credentials to connect. Please check your user_data and/or AMI.')
             else:
                 logger.error('SSH failed with error code %d: %s', exc.returncode, exc.cmd)
             sys.exit(exc.returncode)


### PR DESCRIPTION
Rather than an obscure SSH error, this will tell you when you lack the proper credentials to connect (usually an AMI or user-data error).