### PR TITLE
GPU Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+- **Create** - Fix GPU AMI not being selected.
+- **Parser** - Fix GPU flag not being passed properly to the config dict.
+
+
 ## [1.1.0] - 2024-02-26
+
 ### Added
 - **Create** - Added `destroy_on_create`
 - **Create** - Added `create_timeout` option

--- a/src/forge/create.py
+++ b/src/forge/create.py
@@ -324,8 +324,10 @@ def create_template(n, config, task):
     market = market[-1] if task == 'cluster-worker' else market[0]
     if service:
         if len(user_ami) == 21 and user_ami[:4] == "ami-":
-            ami, disk, disk_device_name = (user_ami, config['disk'], config['disk_device_name'])
+            ami, disk, disk_device_name = (user_ami, user_disk, user_disk_device_name)
         else:
+            if gpu:
+                user_ami += '_gpu'
             ami_info = env_ami.get(user_ami)
             ami, disk, disk_device_name = (ami_info['ami'], ami_info['disk'], ami_info['disk_device_name'])
 
@@ -727,7 +729,7 @@ def get_instance_details(config, task_list):
                 destroy(config)
             sys.exit(1)
 
-        logger.debug('%s OVERRIDE DETAILS | RAM: %s out of %s | CPU: %s with ratio of %s', task, ram, total_ram, cpu, ram2cpu_ratio)
+        logger.debug('%s OVERRIDE DETAILS | RAM: %s out of %s | CPU: %s with ratio of %s', task, task_ram, total_ram, task_cpu, ram2cpu_ratio)
 
         instance_details[task] = {
             'total_capacity': task_worker_count or total_ram,

--- a/src/forge/parser.py
+++ b/src/forge/parser.py
@@ -126,7 +126,7 @@ def add_job_args(parser):
     common_grp.add_argument('--disk', type=positive_int_arg)
     common_grp.add_argument('--valid_time', '--valid-time', type=positive_int_arg)
     common_grp.add_argument('--user_data', '--user-data', nargs='*')
-    common_grp.add_argument('--gpu', action='store_true', dest='gpu_flag')
+    common_grp.add_argument('--gpu', action='store_true', dest='gpu_flag', default=None)
     common_grp.add_argument('--destroy_on_create', '--destroy-on-create', action='store_true', default=None)
 
 

--- a/tests/test_yaml_loader.py
+++ b/tests/test_yaml_loader.py
@@ -164,6 +164,11 @@ def test_check_user_yaml_invalid(mock_exit, bad_config, error_msg, caplog):
       'date': '2021-01-01', 'forge_env': 'dev'},
      {'forge_env': 'dev', 'service': 'single', 'ram': [[64]], 'aws_role': 'forge-test_role-dev',
       'run_cmd': 'dummy.sh dev test', 'gpu_flag': True}),
+    # Job with runtime override of gpu instance
+    ({'yaml': os.path.join(TEST_DIR, 'data', 'single_basic_gpu.yaml'),
+      'date': '2021-01-01', 'forge_env': 'dev', 'gpu_flag': False},
+     {'forge_env': 'dev', 'service': 'single', 'ram': [[64]], 'aws_role': 'forge-test_role-dev',
+      'run_cmd': 'dummy.sh dev test', 'gpu_flag': False}),
     # Job with no runtime overrides and on-demand instance
     ({'yaml': os.path.join(TEST_DIR, 'data', 'single_basic_ondemand.yaml'),
       'date': '2021-01-01', 'forge_env': 'dev'},


### PR DESCRIPTION
This PR fixes 2 bugs:

1. In `parser.py` we had set the default for the `--gpu` flag to `False`. Because of this, if the user specifies `gpu_flag: true` in their yaml file, this gets overridden by the default of `False` and user never gets a GPU instance. This PR changes the default of `--gpu` to `None` like the other boolean flags.
2. In `create_template` of `create.py` we were not checking the `gpu_flag` config option to select the proper admin-defined ami (`single_gpu`) so, users were getting GPU instances but with non-GPU related AMIs installed.