### PR TITLE
Add minute timer after create to engine

### DIFF
--- a/src/forge/engine.py
+++ b/src/forge/engine.py
@@ -1,6 +1,8 @@
 """Run a command on remote EC2, rsync user content, and execute it."""
-import boto3
 import logging
+import time
+
+import boto3
 
 from . import DEFAULT_ARG_VALS, REQUIRED_ARGS
 from .exceptions import ExitHandlerException
@@ -54,6 +56,7 @@ def engine(config):
 
     try:
         create(config)
+        time.sleep(60)
         status = rsync(config)
         status = run(config)
     except ExitHandlerException:


### PR DESCRIPTION
This fixes the issue where the user data does not completely finish before AWS lets us know that the EC2 instance is ready.