### PR TITLE
Allow any arguments from any subcommand

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.1.1
+current_version = 1.2.0
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2025-01-30
+
+### Added
+- **S3 sync** - Allow files to be synced to the Forge instance from an S3 bucket
+
 ## [1.1.1] - 2024-12-12
 
 ### Changed
@@ -67,7 +72,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 - **Initial commit** - Forge source code, unittests, docs, pyproject.toml, README.md, and LICENSE files.
 
-[unreleased]: https://github.com/carsdotcom/cars-forge/compare/v1.1.1...HEAD
+[unreleased]: https://github.com/carsdotcom/cars-forge/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/carsdotcom/cars-forge/compare/v1.1.1...v1.2.0
 [1.1.1]: https://github.com/carsdotcom/cars-forge/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/carsdotcom/cars-forge/compare/v1.0.2...v1.1.0
 [1.0.2]: https://github.com/carsdotcom/cars-forge/compare/v1.0.1...v1.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 - **S3 sync** - Allow files to be synced to the Forge instance from an S3 bucket
 
+### Changed
+- **Subcommand arguments** - Allowed CLI arguments from any subcommand to be specified for any other
+
 ## [1.1.1] - 2024-12-12
 
 ### Changed

--- a/docs/rsync.md
+++ b/docs/rsync.md
@@ -29,3 +29,4 @@ Forge rsync makes it simple for you to copy a folder or file from local to the f
 2. `date`
 3. `all`
 4. `yaml`
+5. `s3_path`

--- a/docs/yaml.md
+++ b/docs/yaml.md
@@ -76,6 +76,7 @@ Each forge command certain parameters. A yaml file with all the parameters can b
 - **run_cmd** - The command that will be ran on the master or single instance. The path is relative to `rsync_path`. Any arguments will be passed to the script as is. Special variables `{env}`, `{date}`, and `{ip}` are available and will be replaced at runtime by the instance values. All commands will run as the root user.
     - Use the `--all` flag to run the script on all the instances in a cluster.
     - E.g. `run_cmd: scripts/run.sh {env} {date} {ip}`
+- **s3_path** - An AWS S3 URI to rsync to the Forge instance. Downloads the file locally and sends it to the instance.
 - **service** - `cluster` or `single`
 - **spot_strategy** - Select the [spot allocation strategy](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2/client/create_fleet.html).
 - **spot_retries** - If using engine mode, sets the number of times to retry a spot instance. Only retries if either market is spot.

--- a/src/forge/__init__.py
+++ b/src/forge/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.1.1"
+__version__ = "1.2.0"
 
 # Default values for forge's essential arguments
 DEFAULT_ARG_VALS = {

--- a/src/forge/cleanup.py
+++ b/src/forge/cleanup.py
@@ -6,8 +6,7 @@ import boto3
 
 from . import REQUIRED_ARGS
 from .common import set_boto_session
-from .parser import add_basic_args, add_general_args, add_env_args
-
+from .parser import add_basic_args, add_general_args, add_env_args, add_job_args, add_action_args
 
 logger = logging.getLogger(__name__)
 
@@ -23,6 +22,8 @@ def cli_cleanup(subparsers):
     parser = subparsers.add_parser('cleanup', description='Cleanup EC2 launch templates')
     add_basic_args(parser)
     add_general_args(parser)
+    add_job_args(parser, suppress=True)
+    add_action_args(parser, suppress=True)
     add_env_args(parser)
 
     REQUIRED_ARGS['cleanup'] = {'forge_env'}

--- a/src/forge/create.py
+++ b/src/forge/create.py
@@ -12,7 +12,7 @@ import botocore.exceptions
 from botocore.exceptions import ClientError
 
 from . import DEFAULT_ARG_VALS, REQUIRED_ARGS
-from .parser import add_basic_args, add_job_args, add_env_args, add_general_args
+from .parser import add_basic_args, add_job_args, add_env_args, add_general_args, add_action_args
 from .common import (ec2_ip, destroy_hook, set_boto_session, exit_callback,
                      user_accessible_vars, FormatEmpty, get_ec2_pricing)
 from .destroy import destroy
@@ -31,6 +31,7 @@ def cli_create(subparsers):
     parser = subparsers.add_parser('create', description='Create EC2')
     add_basic_args(parser)
     add_job_args(parser)
+    add_action_args(parser, suppress=True)
     add_env_args(parser)
     add_general_args(parser)
 

--- a/src/forge/destroy.py
+++ b/src/forge/destroy.py
@@ -7,7 +7,7 @@ from datetime import datetime, timezone, timedelta
 import boto3
 
 from . import DEFAULT_ARG_VALS, REQUIRED_ARGS
-from .parser import add_basic_args, add_general_args, add_env_args
+from .parser import add_basic_args, add_general_args, add_env_args, add_job_args, add_action_args
 from .common import ec2_ip, set_boto_session, get_ec2_pricing
 
 logger = logging.getLogger(__name__)
@@ -24,6 +24,8 @@ def cli_destroy(subparsers):
     parser = subparsers.add_parser('destroy', description='Destroy EC2')
     add_basic_args(parser)
     add_general_args(parser)
+    add_job_args(parser, suppress=True)
+    add_action_args(parser, suppress=True)
     add_env_args(parser)
 
     REQUIRED_ARGS['destroy'] = ['name',

--- a/src/forge/parser.py
+++ b/src/forge/parser.py
@@ -110,27 +110,33 @@ def add_basic_args(parser):
     parser.add_argument('--market', nargs='+', choices={'spot', 'on-demand'})
 
 
-def add_job_args(parser):
+def add_job_args(parser, *, suppress: bool = False):
     """adds job arguments to parser
 
     Parameters
     ----------
     parser : argparse.ArgumentParser
         Argument parser for Forge.main
+    suppress : bool, optional
+        Whether the argument should be suppressed in help messages
     """
+    help_message = None
+    if suppress:
+        help_message = argparse.SUPPRESS
+
     common_grp = parser.add_argument_group('Common job arguments')
-    common_grp.add_argument('--ram', type=list_string)
-    common_grp.add_argument('--cpu', type=list_string)
-    common_grp.add_argument('--ratio', type=list_string)
-    common_grp.add_argument('--aws_role', '--aws-role')
-    common_grp.add_argument('--disk', type=positive_int_arg)
-    common_grp.add_argument('--valid_time', '--valid-time', type=positive_int_arg)
-    common_grp.add_argument('--user_data', '--user-data', nargs='*')
-    common_grp.add_argument('--gpu', action='store_true', dest='gpu_flag', default=None)
-    common_grp.add_argument('--destroy_on_create', '--destroy-on-create', action='store_true', default=None)
+    common_grp.add_argument('--ram', type=list_string, help=help_message)
+    common_grp.add_argument('--cpu', type=list_string, help=help_message)
+    common_grp.add_argument('--ratio', type=list_string, help=help_message)
+    common_grp.add_argument('--aws_role', '--aws-role', help=help_message)
+    common_grp.add_argument('--disk', type=positive_int_arg, help=help_message)
+    common_grp.add_argument('--valid_time', '--valid-time', type=positive_int_arg, help=help_message)
+    common_grp.add_argument('--user_data', '--user-data', nargs='*', help=help_message)
+    common_grp.add_argument('--gpu', action='store_true', dest='gpu_flag', default=None, help=help_message)
+    common_grp.add_argument('--destroy_on_create', '--destroy-on-create', action='store_true', default=None, help=help_message)
 
 
-def add_action_args(parser):
+def add_action_args(parser, *, suppress: bool = False):
     """add action arguments to the parser
 
     These don't create nor destroy jobs, but are used to do things on existing instances
@@ -139,11 +145,17 @@ def add_action_args(parser):
     ----------
     parser : argparse.ArgumentParser
         Argument parser for Forge.main
+    suppress : bool, optional
+        Whether the argument should be suppressed in help messages
     """
+    help_message = None
+    if suppress:
+        help_message = argparse.SUPPRESS
+
     action_grp = parser.add_argument_group('Action Arguments')
-    action_grp.add_argument('--rsync_path', '--rsync-path')
-    action_grp.add_argument('--run_cmd', '--run-cmd')
-    action_grp.add_argument('--all', action='store_true', dest='rr_all')
+    action_grp.add_argument('--rsync_path', '--rsync-path', help=help_message)
+    action_grp.add_argument('--run_cmd', '--run-cmd', help=help_message)
+    action_grp.add_argument('--all', action='store_true', dest='rr_all', help=help_message)
 
 
 def add_env_args(parser):

--- a/src/forge/parser.py
+++ b/src/forge/parser.py
@@ -154,6 +154,7 @@ def add_action_args(parser, *, suppress: bool = False):
 
     action_grp = parser.add_argument_group('Action Arguments')
     action_grp.add_argument('--rsync_path', '--rsync-path', help=help_message)
+    action_grp.add_argument('--s3_path', '--s3-path', help=help_message)
     action_grp.add_argument('--run_cmd', '--run-cmd', help=help_message)
     action_grp.add_argument('--all', action='store_true', dest='rr_all', help=help_message)
 

--- a/src/forge/rsync.py
+++ b/src/forge/rsync.py
@@ -1,8 +1,13 @@
 """Rsync user content to EC2 instance."""
 import logging
 import os
+import re
 import subprocess
 import sys
+import tempfile
+from doctest import debug
+
+import boto3
 
 from . import DEFAULT_ARG_VALS, REQUIRED_ARGS
 from .destroy import destroy
@@ -31,8 +36,7 @@ def cli_rsync(subparsers):
 
     REQUIRED_ARGS['rsync'] = ['name',
                               'service',
-                              'forge_env',
-                              'rsync_path']
+                              'forge_env',]
 
 
 def rsync(config):
@@ -90,7 +94,53 @@ def rsync(config):
                 logger.error('Rsync failed:\n%s', exc.output)
                 return exc.returncode
 
+    def _s3_rsync(config, ip):
+        """downloads a file from S3 and performs a rsync to a given ip
+
+        Parameters
+        ----------
+        config : dict
+            Forge configuration data
+        ip : str
+            IP of the instance to rsync to
+        """
+
+        rval = 0
+
+        s3_loc = config.get('s3_path')
+
+        logger.debug('S3 path: %s', s3_loc)
+
+        s3_uri_pattern = r'(?:s3\:/)?/?(?P<bucket>\S+?)/(?P<key>\S+)'
+
+        match = re.match(s3_uri_pattern, s3_loc)
+        if match:
+            bucket = match.group('bucket')
+            key = match.group('key')
+            name = key.split('/')[-1]
+
+            local_path = f'/tmp/{name}'
+
+            logger.debug('Downloading file from S3 to %s', local_path)
+
+            s3 = boto3.resource('s3')
+            s3.Object(bucket, key).download_file(local_path)
+
+            logger.debug('Successfully downloaded file %s', local_path)
+
+            rval += _rsync({**config, 'rsync_path': local_path}, ip)
+
+            os.remove(local_path)
+        else:
+            rval += 1
+
+        return rval
+
     n_list = get_nlist(config)
+
+    if not config.get('rsync_path') and not config.get('s3_path'):
+        logger.error('No rsync_path or s3_path specified, exiting')
+        sys.exit(1)
 
     for n in n_list:
         try:
@@ -103,8 +153,14 @@ def rsync(config):
                 continue
 
             for ip, _ in targets:
-                logger.info('Rsync destination is %s', ip)
-                rval = _rsync(config, ip)
+                if config.get('rsync_path'):
+                    logger.info('Rsync destination is %s', ip)
+                    rval += _rsync(config, ip)
+
+                if config.get('s3_path'):
+                    logger.info('S3 rsync destination is %s', ip)
+                    rval += _s3_rsync(config, ip)
+
                 if rval:
                     raise ValueError('Rsync command unsuccessful, ending attempts.')
         except ValueError as e:

--- a/src/forge/rsync.py
+++ b/src/forge/rsync.py
@@ -7,7 +7,7 @@ import sys
 from . import DEFAULT_ARG_VALS, REQUIRED_ARGS
 from .destroy import destroy
 from .exceptions import ExitHandlerException
-from .parser import add_basic_args, add_general_args, add_env_args, add_action_args
+from .parser import add_basic_args, add_general_args, add_env_args, add_action_args, add_job_args
 from .common import ec2_ip, key_file, get_ip, get_nlist, exit_callback
 
 logger = logging.getLogger(__name__)
@@ -25,6 +25,7 @@ def cli_rsync(subparsers):
     add_basic_args(parser)
 
     add_general_args(parser)
+    add_job_args(parser, suppress=True)
     add_action_args(parser)
     add_env_args(parser)
 

--- a/src/forge/run.py
+++ b/src/forge/run.py
@@ -6,7 +6,7 @@ import sys
 
 from . import DEFAULT_ARG_VALS, REQUIRED_ARGS
 from .exceptions import ExitHandlerException
-from .parser import add_basic_args, add_general_args, add_env_args, add_action_args
+from .parser import add_basic_args, add_general_args, add_env_args, add_action_args, add_job_args
 from .common import ec2_ip, key_file, get_ip, destroy_hook, user_accessible_vars, FormatEmpty, exit_callback, get_nlist
 from .destroy import destroy
 
@@ -24,6 +24,7 @@ def cli_run(subparsers):
     parser = subparsers.add_parser('run', description='Run command on remote EC2')
     add_basic_args(parser)
     add_general_args(parser)
+    add_job_args(parser, suppress=True)
     add_action_args(parser)
     add_env_args(parser)
 

--- a/src/forge/ssh.py
+++ b/src/forge/ssh.py
@@ -5,7 +5,7 @@ import subprocess
 import sys
 
 from . import DEFAULT_ARG_VALS, REQUIRED_ARGS
-from .parser import add_basic_args, add_general_args, add_env_args
+from .parser import add_basic_args, add_general_args, add_env_args, add_job_args, add_action_args
 from .common import ec2_ip, key_file, get_ip
 
 logger = logging.getLogger(__name__)
@@ -22,6 +22,8 @@ def cli_ssh(subparsers):
     parser = subparsers.add_parser('ssh', description='SSH to EC2 instance')
     add_basic_args(parser)
     add_general_args(parser)
+    add_job_args(parser, suppress=True)
+    add_action_args(parser, suppress=True)
     add_env_args(parser)
 
     REQUIRED_ARGS['ssh'] = ['name',

--- a/src/forge/start.py
+++ b/src/forge/start.py
@@ -5,7 +5,7 @@ import sys
 import boto3
 
 from . import REQUIRED_ARGS
-from .parser import add_basic_args, add_general_args, add_env_args
+from .parser import add_basic_args, add_general_args, add_env_args, add_job_args, add_action_args
 from .common import ec2_ip, get_ip, set_boto_session, get_nlist
 
 logger = logging.getLogger(__name__)
@@ -26,6 +26,8 @@ def cli_start(subparsers):
     parser = subparsers.add_parser('start', description='start an on-demand EC2')
     add_basic_args(parser)
     add_general_args(parser)
+    add_job_args(parser, suppress=True)
+    add_action_args(parser, suppress=True)
     add_env_args(parser)
 
     REQUIRED_ARGS['start'] = ['name',

--- a/src/forge/stop.py
+++ b/src/forge/stop.py
@@ -5,7 +5,7 @@ import sys
 import boto3
 
 from . import REQUIRED_ARGS
-from .parser import add_basic_args, add_general_args, add_env_args
+from .parser import add_basic_args, add_general_args, add_env_args, add_job_args, add_action_args
 from .common import ec2_ip, get_ip, set_boto_session, get_nlist
 
 logger = logging.getLogger(__name__)
@@ -22,6 +22,8 @@ def cli_stop(subparsers):
     parser = subparsers.add_parser('stop', description='Stop an on-demand EC2')
     add_basic_args(parser)
     add_general_args(parser)
+    add_job_args(parser, suppress=True)
+    add_action_args(parser, suppress=True)
     add_env_args(parser)
 
     REQUIRED_ARGS['stop'] = ['name',

--- a/src/forge/yaml_loader.py
+++ b/src/forge/yaml_loader.py
@@ -149,6 +149,7 @@ def check_user_yaml(user_yaml, additional_config: list = None):
         Optional('run_cmd'): And(str, len, error='Invalid run_cmd'),
         Optional('service'): And(str, len, Or('single', 'cluster'), error='Invalid Service'),
         Optional('spot_retries'): And(Use(int), positive_int),
+        Optional('s3_path'): And(str),
         Optional('user_data'): And(list),
         Optional('valid_time'): And(Use(int), positive_int),
         Optional('workers'): And(Use(int), positive_int),

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,6 +2,7 @@
 # pylint: disable=W0621
 import os
 from unittest import mock
+from xmlrpc.client import Fault
 
 import pytest
 import yaml
@@ -43,7 +44,7 @@ def load_admin_cfg():
       'home_dir': os.path.dirname(FORGE_DIR), 'yaml_dir': os.path.join(TEST_DIR, 'data'), 'user': 'test_user',
       'ami': 'single_ami', 'forge_version': False, 'config_dir': os.path.join(TEST_CFG_DIR, 'dev'),
       'region': 'us-east-1', 'destroy_after_success': True, 'destroy_after_failure': True, 'default_ratio': [8, 8],
-      'valid_time': 8, 'ec2_max': 768, 'spot_strategy': 'price-capacity-optimized'}),
+      'valid_time': 8, 'ec2_max': 768, 'spot_strategy': 'price-capacity-optimized', 'rr_all': False}),
     # Destroy job; passing the relative path to a yaml
     (['forge', 'destroy', '--yaml', os.path.join(TEST_DIR_REL, 'data', 'single_intermediate.yaml')],
      {'name': 'test-single-intermediate', 'log_level': 'INFO',
@@ -53,7 +54,7 @@ def load_admin_cfg():
       'yaml_dir': os.path.join(TEST_DIR, 'data'), 'user': 'test_user', 'ami': 'single_ami',
       'forge_version': False, 'config_dir': os.path.join(TEST_CFG_DIR, 'dev'), 'region': 'us-east-1',
       'destroy_after_success': True, 'destroy_after_failure': True, 'default_ratio': [8, 8], 'valid_time': 8,
-      'ec2_max': 768, 'spot_strategy': 'price-capacity-optimized'}),
+      'ec2_max': 768, 'spot_strategy': 'price-capacity-optimized', 'rr_all': False}),
     # Destroy job; overriding log_level
     (['forge', 'destroy', '--yaml', os.path.join(TEST_DIR, 'data', 'single_intermediate.yaml'), '--log_level', 'debug'],
      {'name': 'test-single-intermediate', 'log_level': 'DEBUG',
@@ -63,7 +64,7 @@ def load_admin_cfg():
       'home_dir': os.path.dirname(FORGE_DIR), 'yaml_dir': os.path.join(TEST_DIR, 'data'), 'user': 'test_user',
       'ami': 'single_ami', 'forge_version': False, 'config_dir': os.path.join(TEST_CFG_DIR, 'dev'),
       'region': 'us-east-1', 'destroy_after_success': True, 'destroy_after_failure': True, 'default_ratio': [8, 8],
-      'valid_time': 8, 'ec2_max': 768, 'spot_strategy': 'price-capacity-optimized'}),
+      'valid_time': 8, 'ec2_max': 768, 'spot_strategy': 'price-capacity-optimized', 'rr_all': False}),
     # Destroy job; overriding market
     (['forge', 'destroy', '--yaml', os.path.join(TEST_DIR, 'data', 'single_intermediate.yaml'),
       '--market', 'on-demand'],
@@ -74,7 +75,7 @@ def load_admin_cfg():
       'yaml_dir': os.path.join(TEST_DIR, 'data'), 'user': 'test_user', 'ami': 'single_ami', 'forge_version': False,
       'config_dir': os.path.join(TEST_CFG_DIR, 'dev'), 'region': 'us-east-1', 'destroy_after_success': True,
       'destroy_after_failure': True, 'default_ratio': [8, 8], 'valid_time': 8, 'ec2_max': 768,
-      'spot_strategy': 'price-capacity-optimized'}),
+      'spot_strategy': 'price-capacity-optimized', 'rr_all': False}),
     # Destroy job; no market
     (['forge', 'destroy', '--yaml', os.path.join(TEST_DIR, 'data', 'single_basic.yaml'), '--forge_env', 'dev'],
      {'name': 'test-single-basic', 'log_level': 'INFO', 'yaml': os.path.join(TEST_DIR, 'data', 'single_basic.yaml'),
@@ -83,7 +84,7 @@ def load_admin_cfg():
       'home_dir': os.path.dirname(FORGE_DIR), 'yaml_dir': os.path.join(TEST_DIR, 'data'), 'user': 'test_user',
       'ami': 'single_ami', 'forge_version': False, 'config_dir': os.path.join(TEST_CFG_DIR, 'dev'),
       'region': 'us-east-1', 'destroy_after_success': True, 'destroy_after_failure': True, 'default_ratio': [8, 8],
-      'valid_time': 8, 'ec2_max': 768, 'spot_strategy': 'price-capacity-optimized'}),
+      'valid_time': 8, 'ec2_max': 768, 'spot_strategy': 'price-capacity-optimized', 'rr_all': False}),
     # Configure job
     (['forge', 'configure'],
      {'forge_version': False, 'job': 'configure', 'log_level': 'INFO'}),
@@ -96,7 +97,7 @@ def load_admin_cfg():
       'home_dir': os.path.dirname(FORGE_DIR), 'yaml_dir': os.path.join(TEST_DIR, 'data'), 'user': 'test_user',
       'ami': 'single_ami', 'forge_version': False, 'config_dir': os.path.join(TEST_CFG_DIR, 'dev'),
       'region': 'us-east-1', 'destroy_after_success': True, 'destroy_after_failure': True, 'default_ratio': [8, 8],
-      'valid_time': 8, 'ec2_max': 768, 'spot_strategy': 'price-capacity-optimized'}),
+      'valid_time': 8, 'ec2_max': 768, 'spot_strategy': 'price-capacity-optimized', 'rr_all': False}),
     # Create job; setting gpu
     (['forge', 'create', '--yaml', os.path.join(TEST_DIR, 'data', 'single_basic.yaml'), '--forge_env', 'dev', '--gpu'],
      {'name': 'test-single-basic', 'log_level': 'INFO', 'yaml': os.path.join(TEST_DIR, 'data', 'single_basic.yaml'),
@@ -105,7 +106,7 @@ def load_admin_cfg():
       'home_dir': os.path.dirname(FORGE_DIR), 'yaml_dir': os.path.join(TEST_DIR, 'data'), 'user': 'test_user',
       'ami': 'single_ami', 'forge_version': False, 'config_dir': os.path.join(TEST_CFG_DIR, 'dev'),
       'region': 'us-east-1', 'destroy_after_success': True, 'destroy_after_failure': True, 'default_ratio': [8, 8],
-      'valid_time': 8, 'ec2_max': 768, 'spot_strategy': 'price-capacity-optimized'}),
+      'valid_time': 8, 'ec2_max': 768, 'spot_strategy': 'price-capacity-optimized', 'rr_all': False}),
 ])
 def test_forge_main(mock_pass, mock_execute, mock_keys, mock_config_dir, cli_call, exp_config, load_admin_cfg):
     """Test the config after calling forge via the command line."""


### PR DESCRIPTION
This update allows arguments from any subcommand to be included for any other subcommand to prevent errors when modifying an existing Forge call from one subcommand to another. This allows options like `--ram` to be specified for `forge rsync`, or `--run-cmd` to be used with `forge destroy`.

To ensure that this does not interfere with documentation, the supplemental arguments have been suppressed in the help strings for the subcommands which they have no effect. This change to purely to make Forge more ergonomic for the user.