### PR TITLE
Add IMDSv2 Support

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.3.0
+current_version = 1.3.1
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.1]
+
+### Added
+- **Create** - Added support for AWS IMDS v2
+
 ## [1.3.0]
 
 ### Added
@@ -85,6 +90,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - **Initial commit** - Forge source code, unittests, docs, pyproject.toml, README.md, and LICENSE files.
 
 [unreleased]: https://github.com/carsdotcom/cars-forge/compare/v1.3.0...HEAD
+[1.3.1]: https://github.com/carsdotcom/cars-forge/compare/v1.3.0...v1.3.1
 [1.3.0]: https://github.com/carsdotcom/cars-forge/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/carsdotcom/cars-forge/compare/v1.1.1...v1.2.0
 [1.1.1]: https://github.com/carsdotcom/cars-forge/compare/v1.1.0...v1.1.1

--- a/src/forge/__init__.py
+++ b/src/forge/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.3.0"
+__version__ = "1.3.1"
 
 # Default values for forge's essential arguments
 DEFAULT_ARG_VALS = {

--- a/src/forge/configuration.py
+++ b/src/forge/configuration.py
@@ -31,6 +31,7 @@ class Configuration:
     ami: Optional[str] = None
     app_dir: Optional[str] = None
     aws_az: Optional[str] = None
+    aws_imds_v2: Optional[bool] = None
     aws_multi_az: Optional[dict] = None
     aws_profile: Optional[str] = None
     aws_region: Optional[str] = None
@@ -55,7 +56,7 @@ class Configuration:
     market_failover: Optional[bool] = None  # ToDo: Remove
     name: Optional[str] = None
     on_demand_failover: Optional[bool] = None
-    ratio: Optional[MachineSpec] = field(default_factory=lambda: DEFAULT_ARG_VALS['default_ratio'])
+    ratio: Optional[MachineSpec] = None #field(default_factory=lambda: DEFAULT_ARG_VALS['default_ratio'])
     ram: Optional[MachineSpec] = None
     rr_all: Optional[bool] = None
     rsync_path: Optional[str] = None

--- a/src/forge/create.py
+++ b/src/forge/create.py
@@ -369,6 +369,8 @@ def create_template(n, config: Configuration, task):
 
     valid_tag = [{'Key': 'valid_until', 'Value': datetime.strftime(valid_until, "%Y-%m-%dT%H:%M:%SZ")}]
 
+    imds_v2 = 'required' if config.aws_imds_v2 else 'optional'
+
     response = client.create_launch_template(
         LaunchTemplateName=n,
         LaunchTemplateData={
@@ -383,6 +385,7 @@ def create_template(n, config: Configuration, task):
             'InstanceInitiatedShutdownBehavior': 'terminate',
             'UserData': u,
             'SecurityGroupIds': [sg],
+            'MetadataOptions': {'HttpTokens': imds_v2},
             **specs
         },
         TagSpecifications=[{

--- a/src/forge/parser.py
+++ b/src/forge/parser.py
@@ -171,6 +171,7 @@ def add_env_args(parser):
     env_cfg_grp.add_argument('--aws_profile', '--aws-profile')
     env_cfg_grp.add_argument('--aws_az', '--aws-az')
     env_cfg_grp.add_argument('--aws_act_num', '--aws-account-num')
+    env_cfg_grp.add_argument('--aws_imds_v2', '--aws-imds-v2', action='store_true', default=None)
     env_cfg_grp.add_argument('--aws_subnet', '--aws-subnet')
     env_cfg_grp.add_argument('--ec2_key', '--ec2-key')
     env_cfg_grp.add_argument('--aws_security_group', '--aws_security-group')


### PR DESCRIPTION
This will add support for the Instance Metadata Service (IMDS) version 2. This version is preferred as it gives better security than version 1. This adds the ability to enable it in the environmental yaml, user yaml, and command line.

This will also bump the Forge version to 1.3.1