### PR TITLE
Fix AMI bug in user data checks

### DIFF
--- a/src/forge/create.py
+++ b/src/forge/create.py
@@ -334,7 +334,7 @@ def create_template(n, config: Configuration, task):
 
         if ami_or_service:
             if isinstance(ud[ami_or_service], str):
-                with open(os.path.join(config_dir, ud[user_ami]), 'r') as f:
+                with open(os.path.join(config_dir, ud[ami_or_service]), 'r') as f:
                     ud = fmt.format(f.read(), **user_accessible_vars(config, market=market, task=task))
             else:
                 for k, v in ud[ami_or_service].items():


### PR DESCRIPTION
Forge was using the wrong variable to pull the user data if an AMI ID was specified. This fixes that bug. As this is part of a fix of a prior PR, the version has not been bumped.