### PR TITLE
Add AMI Flag to CLI Options

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.3.3
+current_version = 1.3.4
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.4]
+
+### Changed
+- **Parser** - Added AMI flag to the CLI options
+
 ## [1.3.3]
 
 ### Changed
@@ -99,7 +104,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 - **Initial commit** - Forge source code, unittests, docs, pyproject.toml, README.md, and LICENSE files.
 
-[unreleased]: https://github.com/carsdotcom/cars-forge/compare/v1.3.3...HEAD
+[unreleased]: https://github.com/carsdotcom/cars-forge/compare/v1.3.4...HEAD
+[1.3.4]: https://github.com/carsdotcom/cars-forge/compare/v1.3.3...v1.3.4
 [1.3.3]: https://github.com/carsdotcom/cars-forge/compare/v1.3.2...v1.3.3
 [1.3.2]: https://github.com/carsdotcom/cars-forge/compare/v1.3.1...v1.3.2
 [1.3.1]: https://github.com/carsdotcom/cars-forge/compare/v1.3.0...v1.3.1

--- a/docs/environmental_yaml.md
+++ b/docs/environmental_yaml.md
@@ -60,6 +60,7 @@ https://github.com/carsdotcom/cars-forge/blob/main/examples/env_yaml_example/exa
 	    error: "Invalid Spark version. Only 2.3, 3.0, and 3.1 are supported."
     ```
 - **aws_az** - The [AWS availability zone](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html) where Forge will create the EC2 instance. If set, multi-az placement will be disabled.
+- **aws_imds_v2** - Toggle if [AWS IMDSv2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html) is required.
 - **aws_region** - The AWS region for Forge to run in- **aws_profile** - [AWS CLI profile](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html) to use
 - **aws_security_group** - [AWS Security Group](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-security-groups.html) for the instance
 - **aws_subnet** - [AWS subnet](https://docs.aws.amazon.com/vpc/latest/userguide/configure-subnets.html) where the EC2s will run
@@ -75,9 +76,11 @@ https://github.com/carsdotcom/cars-forge/blob/main/examples/env_yaml_example/exa
 	- default is [8, 8]
 - **ec2_amis** - A dictionary of dictionaries to store [AMI](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html) info.
 	- Needs three parameters: 
-			- ami id
-			- minimum disk size
-			- [device name](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/device_naming.html)
+		- ami id
+        - minimum disk size
+        - [device name](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/device_naming.html)
+    - Optional parameters:
+      	- [AWS IMDS max hops](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-options.html)
 	- E.g.
 	```yaml
 	ec2_amis:
@@ -85,6 +88,7 @@ https://github.com/carsdotcom/cars-forge/blob/main/examples/env_yaml_example/exa
 	    ami: ami-abcdefghi12345678
 	    disk: 30
 	    disk_device_name: /dev/sda1
+  		aws_imds_max_hops: 2
 	  cluster:
 	    ami: ami-12345678abcdefghi
 	    disk: 30
@@ -93,6 +97,7 @@ https://github.com/carsdotcom/cars-forge/blob/main/examples/env_yaml_example/exa
 	    ami: ami-abcdefghi00000000
 	    disk: 90
 	    disk_device_name: /dev/sda1
+ 		aws_imds_max_hops: 2
 	```
 - **ec2_key** - The [key pair](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html) name used to ssh into the EC2. This will be stored in `forge_pem_secret`
 - **ec2_max** - Override the default maximum amount of RAM a single instance can have. The default is 768.

--- a/docs/environmental_yaml.md
+++ b/docs/environmental_yaml.md
@@ -88,7 +88,7 @@ https://github.com/carsdotcom/cars-forge/blob/main/examples/env_yaml_example/exa
 	    ami: ami-abcdefghi12345678
 	    disk: 30
 	    disk_device_name: /dev/sda1
-  		aws_imds_max_hops: 2
+	    aws_imds_max_hops: 2
 	  cluster:
 	    ami: ami-12345678abcdefghi
 	    disk: 30
@@ -97,7 +97,7 @@ https://github.com/carsdotcom/cars-forge/blob/main/examples/env_yaml_example/exa
 	    ami: ami-abcdefghi00000000
 	    disk: 90
 	    disk_device_name: /dev/sda1
- 		aws_imds_max_hops: 2
+	    aws_imds_max_hops: 2
 	```
 - **ec2_key** - The [key pair](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html) name used to ssh into the EC2. This will be stored in `forge_pem_secret`
 - **ec2_max** - Override the default maximum amount of RAM a single instance can have. The default is 768.

--- a/docs/yaml.md
+++ b/docs/yaml.md
@@ -6,7 +6,19 @@
 
 Each forge command certain parameters. A yaml file with all the parameters can be provided or you can submit the parameters as a CLI parameter at runtime. The CLI parameters will always overwrite the yaml parameters.
 
+- **ami** - Sets the AMI to be used
+  - Can be set as the name of an AMI in the `ec2_amis` data structure in the environmental YAML.
+    ```yaml
+    ami: single
+    ```
+  - If this is set to an AMI ID then `disk` and `disk_device_name` must be set as well.
+    ```yaml
+    ami: ami-000000000000000000
+    disk: 30
+    disk_device_name: /dev/sda1
+    ```
 - **aws_role** - The IAM role forge-*aws_role*-*forge_env* will be attached to the EC2s spun up by Forge.
+- **aws_imds_v2** - Toggle if [AWS IMDSv2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html) is required.
 - **cpu** - Minimum amount of vCPU required. Can be a range e.g. [2, 4].
     - If using a cluster, you must specify both the master and worker. Master first, worker second. 
       ```yaml

--- a/src/forge/__init__.py
+++ b/src/forge/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.3.3"
+__version__ = "1.3.4"
 
 # Default values for forge's essential arguments
 DEFAULT_ARG_VALS = {

--- a/src/forge/create.py
+++ b/src/forge/create.py
@@ -313,6 +313,10 @@ def create_template(n, config: Configuration, task):
     market = market[-1] if task == 'cluster-worker' else market[0]
     if service:
         if user_ami[:4] == "ami-":
+            if not user_disk or not user_disk_device_name:
+                logger.error('disk and disk_device_name must be specified when manually setting an AMI ID')
+                sys.exit(1)
+
             ami, disk, disk_device_name = (user_ami, user_disk, user_disk_device_name)
         else:
             if gpu:

--- a/src/forge/parser.py
+++ b/src/forge/parser.py
@@ -134,6 +134,8 @@ def add_job_args(parser, *, suppress: bool = False):
     common_grp.add_argument('--user_data', '--user-data', nargs='*', help=help_message)
     common_grp.add_argument('--gpu', action='store_true', dest='gpu_flag', default=None, help=help_message)
     common_grp.add_argument('--destroy_on_create', '--destroy-on-create', action='store_true', default=None, help=help_message)
+    common_grp.add_argument('--ami', help=help_message)
+    common_grp.add_argument('--disk_device_name', '--disk-device-name', help=help_message)
 
 
 def add_action_args(parser, *, suppress: bool = False):


### PR DESCRIPTION
This adds the `--ami` and `--disk-device-name` flags to the CLI options so that the AMI can be fully set via the command line. When setting using an AMI ID it is important to set `ami`, `disk`, `disk_device_name`, and possible `aws_imds_max_hops`. Now all of these have CLI options.