### PR TITLE
v1.3.5 - Allow multiple security groups to be passed

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.3.4
+current_version = 1.3.5
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.5]
+
+### Changed
+- **Configuration** - Allowed for a list of security group IDs rather than just a single one
+- **Create** - Added checks for if security groups are passed or not
+- **Parser** - Allowed multiple security groups to be passed via the CLI
+
 ## [1.3.4]
 
 ### Changed
@@ -104,7 +111,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 - **Initial commit** - Forge source code, unittests, docs, pyproject.toml, README.md, and LICENSE files.
 
-[unreleased]: https://github.com/carsdotcom/cars-forge/compare/v1.3.4...HEAD
+[unreleased]: https://github.com/carsdotcom/cars-forge/compare/v1.3.5...HEAD
+[1.3.5]: https://github.com/carsdotcom/cars-forge/compare/v1.3.4...v1.3.5
 [1.3.4]: https://github.com/carsdotcom/cars-forge/compare/v1.3.3...v1.3.4
 [1.3.3]: https://github.com/carsdotcom/cars-forge/compare/v1.3.2...v1.3.3
 [1.3.2]: https://github.com/carsdotcom/cars-forge/compare/v1.3.1...v1.3.2

--- a/docs/environmental_yaml.md
+++ b/docs/environmental_yaml.md
@@ -62,7 +62,7 @@ https://github.com/carsdotcom/cars-forge/blob/main/examples/env_yaml_example/exa
 - **aws_az** - The [AWS availability zone](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html) where Forge will create the EC2 instance. If set, multi-az placement will be disabled.
 - **aws_imds_v2** - Toggle if [AWS IMDSv2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html) is required.
 - **aws_region** - The AWS region for Forge to run in- **aws_profile** - [AWS CLI profile](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html) to use
-- **aws_security_group** - [AWS Security Group](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-security-groups.html) for the instance
+- **aws_security_group** - [AWS Security Group IDs](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-security-groups.html) for the instance. This can be a single security group ID or a list of them.
 - **aws_subnet** - [AWS subnet](https://docs.aws.amazon.com/vpc/latest/userguide/configure-subnets.html) where the EC2s will run
 - **aws_multi_az** - [AWS subnet](https://docs.aws.amazon.com/vpc/latest/userguide/configure-subnets.html) where the EC2s will run organized by AZ
   - E.g.

--- a/src/forge/__init__.py
+++ b/src/forge/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.3.4"
+__version__ = "1.3.5"
 
 # Default values for forge's essential arguments
 DEFAULT_ARG_VALS = {

--- a/src/forge/configuration.py
+++ b/src/forge/configuration.py
@@ -37,7 +37,7 @@ class Configuration:
     aws_profile: Optional[str] = None
     aws_region: Optional[str] = None
     aws_role: Optional[str] = None
-    aws_security_group: Optional[str] = None
+    aws_security_group: Optional[list[str]] = None
     aws_subnet: Optional[str] = None
     config_dir: Optional[str] = None
     cpu: Optional[MachineSpec] = None
@@ -236,6 +236,7 @@ class Configuration:
         aws_region = config_dict.get('aws_region')
         aws_multi_az = config_dict.get('aws_multi_az')
         aws_subnet = config_dict.get('aws_subnet')
+        aws_security_group = config_dict.get('aws_security_group')
 
         cpu = config_dict.get('cpu')
         ram = config_dict.get('ram')
@@ -261,6 +262,10 @@ class Configuration:
 
         if aws_region:
             config_dict['region'] = aws_region
+
+        if aws_security_group:
+            if isinstance(aws_security_group, str):
+                config_dict['aws_security_group'] = [aws_security_group]
 
         def _parse_list(option):
             """Parse a list option.

--- a/src/forge/create.py
+++ b/src/forge/create.py
@@ -375,6 +375,9 @@ def create_template(n, config: Configuration, task):
     tags.append({'Key': 'forge-name', 'Value': n})
     specs = {'TagSpecifications': [{'ResourceType': 'instance', 'Tags': tags}]} if tags else {}
 
+    if sg:
+        specs['SecurityGroupIds'] = sg
+
     valid_tag = [{'Key': 'valid_until', 'Value': datetime.strftime(valid_until, "%Y-%m-%dT%H:%M:%SZ")}]
 
     imds_v2 = 'required' if config.aws_imds_v2 else 'optional'
@@ -396,7 +399,6 @@ def create_template(n, config: Configuration, task):
             'KeyName': key,
             'InstanceInitiatedShutdownBehavior': 'terminate',
             'UserData': u,
-            'SecurityGroupIds': [sg],
             'MetadataOptions': metadata_options,
             **specs
         },

--- a/src/forge/parser.py
+++ b/src/forge/parser.py
@@ -177,7 +177,7 @@ def add_env_args(parser):
     env_cfg_grp.add_argument('--aws_imds_max_hops', '--aws-imds-max-hops', type=int, default=None)
     env_cfg_grp.add_argument('--aws_subnet', '--aws-subnet')
     env_cfg_grp.add_argument('--ec2_key', '--ec2-key')
-    env_cfg_grp.add_argument('--aws_security_group', '--aws_security-group')
+    env_cfg_grp.add_argument('--aws_security_group', '--aws_security-group', nargs='+')
     env_cfg_grp.add_argument('--excluded_ec2s', '--excluded-ec2s', nargs='+', metavar='EC2_TYPE', default=None)
     env_cfg_grp.add_argument('--destroy_after_success', '--destroy-after-success', action='store_true', default=None)
     env_cfg_grp.add_argument('--destroy_after_failure', '--destroy-after-failure', action='store_true', default=None)


### PR DESCRIPTION
This PR allows for multiple security groups to be passed via the CLI or in the environmental YAML. This adds functionality that other parts of the organization rely upon without affecting the compatibility with existing configurations.