### PR TITLE
Fix: Add SSH keepalives to prevent silent PrivateLink connection hangs

### DIFF
--- a/src/forge/rsync.py
+++ b/src/forge/rsync.py
@@ -78,7 +78,7 @@ def rsync(config: Configuration):
                 logger.error("File or folder from 'rsync_path' parameter not found: %s", rsync_loc)
                 sys.exit(1)
 
-            cmd = 'rsync -rave "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no'
+            cmd = 'rsync -rave "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o ServerAliveInterval=60 -o ServerAliveCountMax=5 -o ConnectTimeout=30'
             cmd += f' -i {pem_path}" {rsync_loc} root@{ip}:/root/'
 
             try:

--- a/src/forge/run.py
+++ b/src/forge/run.py
@@ -80,7 +80,7 @@ def run(config: Configuration):
         with key_file(pem_secret, region, profile) as pem_path:
             fmt = FormatEmpty()
             run_cmd = fmt.format(run_cmd, **user_accessible_vars(config, market=market, task=task, ip=ip))
-            cmd = 'ssh -t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no'
+            cmd = 'ssh -t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o ServerAliveInterval=60 -o ServerAliveCountMax=5 -o ConnectTimeout=30'
             cmd += f' -i {pem_path} root@{ip} /root/{run_cmd}'
 
             try:

--- a/src/forge/ssh.py
+++ b/src/forge/ssh.py
@@ -64,7 +64,7 @@ def ssh(config: Configuration):
 
     logger.info('Connecting to the instance.')
     with key_file(pem_secret, region, profile) as pem_path:
-        cmd = 'ssh -t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no'
+        cmd = 'ssh -t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o ServerAliveInterval=60 -o ServerAliveCountMax=5 -o ConnectTimeout=30'
         cmd += f' -i {pem_path} root@{ip}'
 
         try:


### PR DESCRIPTION
## Problem

Airflow jobs running via `forge engine` over AWS PrivateLink occasionally hang indefinitely. When the PrivateLink TCP connection is silently dropped (AWS NLB idle timeout is ~350s by default), the SSH client has no way to detect it and blocks forever. This propagates all the way up:

`subprocess.run()` → `forge engine` → `start_main.sh` → `CarsBashOperator` → Airflow task stuck in `running` → all downstream tasks blocked

## Root Cause

All SSH invocations in `run.py`, `rsync.py`, and `ssh.py` were missing keepalive and timeout options:

```python
# Before — hangs forever on silent TCP drop
cmd = 'ssh -t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no'
```

## Fix

Added `ServerAliveInterval=60`, `ServerAliveCountMax=5`, and `ConnectTimeout=30` to all three SSH call sites:

```python
# After — detects dead connection within ~5 minutes and exits non-zero
cmd = 'ssh -t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o ServerAliveInterval=60 -o ServerAliveCountMax=5 -o ConnectTimeout=30'
```

**Behavior after fix:**
- SSH sends a keepalive every 60s
- After 5 consecutive failures (~5 min), SSH exits non-zero
- `subprocess.run()` raises `CalledProcessError` → forge exits → `CarsBashOperator` raises `AirflowException`
- Airflow task moves from `running` → `failed`
- Existing `on_failure_callback` (Slack + PagerDuty) fires automatically

## Files Changed

- `src/forge/run.py` — SSH command used to execute Spark jobs on EC2
- `src/forge/rsync.py` — SSH tunnel used by rsync to copy files to EC2
- `src/forge/ssh.py` — Interactive SSH command